### PR TITLE
Added clean workspace directive

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -233,7 +233,7 @@ pipeline {
           jacoco changeBuildStatus: true, sourcePattern: '**/src/main/java,**/src/main/kotlin'
           cleanWs()
         }
-      always {
+      failure {
         cleanWs()
       }
   }


### PR DESCRIPTION
This addresses the issue of Jenkins not being able to pull code and giving Error code 130
Workspace will be completely cleaned now