### PR TITLE
docs: complete README overhaul and add DEVELOPMENT/ARCHITECTURE guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,173 +1,264 @@
 # AKILIMO Mobile
 
 [![Android CI](https://github.com/IITA-AKILIMO/akilimo-mobile/actions/workflows/android.yml/badge.svg)](https://github.com/IITA-AKILIMO/akilimo-mobile/actions/workflows/android.yml)
-[![Quality gate](https://sonar.munywele.co.ke/api/project_badges/quality_gate?project=IITA-AKILIMO_akilimo-mobile_abcb50d1-1abd-4e32-bd76-b385f65cfc5d&token=sqb_31a18546176db4735c7afc45a9561b931d046803)](https://sonar.munywele.co.ke/dashboard?id=IITA-AKILIMO_akilimo-mobile_abcb50d1-1abd-4e32-bd76-b385f65cfc5d)
-[![Security Issues](https://sonar.munywele.co.ke/api/project_badges/measure?project=IITA-AKILIMO_akilimo-mobile_abcb50d1-1abd-4e32-bd76-b385f65cfc5d&metric=software_quality_security_issues&token=sqb_31a18546176db4735c7afc45a9561b931d046803)](https://sonar.munywele.co.ke/dashboard?id=IITA-AKILIMO_akilimo-mobile_abcb50d1-1abd-4e32-bd76-b385f65cfc5d)
-[![Maintainability Rating](https://sonar.munywele.co.ke/api/project_badges/measure?project=IITA-AKILIMO_akilimo-mobile_abcb50d1-1abd-4e32-bd76-b385f65cfc5d&metric=software_quality_maintainability_rating&token=sqb_31a18546176db4735c7afc45a9561b931d046803)](https://sonar.munywele.co.ke/dashboard?id=IITA-AKILIMO_akilimo-mobile_abcb50d1-1abd-4e32-bd76-b385f65cfc5d)
 
-## Overview
+AKILIMO Mobile is an Android application for delivering site-specific agronomic recommendations to farmers and extension agents. The app combines location-aware data collection, crop/use-case workflows, and remote recommendation APIs with offline-friendly local storage.
 
-AKILIMO Mobile is an Android-based decision support tool developed by the International Institute of
-Tropical Agriculture (IITA) under the African Cassava Agronomy Initiative (ACAI).
+---
 
-The app provides site-specific agronomic advice tailored to farmers in sub-Saharan Africa, enabling
-them to optimize fertilizer
-use, improve yields, and make informed farming decisions for crops including cassava, maize, and
-sweet potato.
+## Table of Contents
 
-## Features
+- [What this app does](#what-this-app-does)
+- [Current technical baseline](#current-technical-baseline)
+- [Project structure](#project-structure)
+- [Getting started](#getting-started)
+- [Configuration and secrets](#configuration-and-secrets)
+- [Build and run](#build-and-run)
+- [Testing and quality checks](#testing-and-quality-checks)
+- [Release workflow](#release-workflow)
+- [Troubleshooting](#troubleshooting)
+- [Documentation index](#documentation-index)
 
-- **Customized Fertilizer Recommendations**: Offers tailored advice on fertilizer application based
-  on user inputs such as location, yield targets, and input prices.
+---
 
-- **Intercropping Support**: Provides recommendations for intercropping systems (cassava-maize).
+## What this app does
 
-- **Planting Practices**: Guidance on optimal planting times and methods.
+AKILIMO Mobile supports agronomy decision workflows such as:
 
-- **Multi-Channel Delivery**: Provides recommendations directly within the app, via SMS, or through
-  email.
+- Fertilizer recommendation flows (including intercropping variants)
+- Produce market and yield-related flows (cassava, maize, sweet potato)
+- Tillage and weed-management related cost flows
+- Location-aware recommendations via on-device location + map-assisted picking
+- Multi-language UX support (English, Swahili, Kinyarwanda, French)
+- Background synchronization of reference datasets (e.g., fertilizer catalog/prices, market data)
 
-- **Location-Based Advice**: Uses GPS and mapping technology to provide site-specific
-  recommendations.
+From current source configuration, the app includes country support for:
 
-- **Multi-Country Support**: Available for farmers in Tanzania, Rwanda, Ghana, and Burundi.
+- Nigeria (`NG`)
+- Tanzania (`TZ`)
+- Ghana (`GH`)
+- Rwanda (`RW`)
+- Burundi (`BI`)
 
-- **Multilingual Interface**: Supports English, Kiswahili, and Kinyarwanda.
+---
 
-- **User-Friendly Interface**: Designed with simplicity in mind to cater to farmers with varying
-  levels of digital literacy.
+## Current technical baseline
 
-## Supported Countries
-
-- Tanzania
-- Rwanda
-- Ghana
-- Burundi
-
-## Installation
-
-To build and run the AKILIMO Mobile app locally:
-
-1. Clone the repository:
-
-   ```bash
-   git clone https://github.com/IITA-AKILIMO/akilimo-mobile.git
-   cd akilimo-mobile
-   ```
-
-2. Open the project in Android Studio.
-
-3. Configure your local.properties file with required API keys:
-    - Mapbox API key
-    - Firebase configuration
-
-4. Build the project:
-
-   ```bash
-   ./gradlew build
-   ```
-
-5. Run the app on an emulator or physical device:
-
-   ```bash
-   ./gradlew installDebug
-   ```
-
-## Technology Stack
-
+- **Platform**: Android app (`:app` single-module project)
 - **Language**: Kotlin
-- **Minimum SDK**: 19 (Android 4.4 KitKat)
-- **Target SDK**: 34 (Android 14)
-- **Architecture**: MVVM (Model-View-ViewModel)
-- **Database**: Room Persistence Library
-- **Networking**: Retrofit, OkHttp
-- **JSON Parsing**: Jackson
-- **Mapping**: Mapbox
-- **UI Components**: Material Design, RecyclerView, CardView
-- **Error Tracking**: Sentry
-- **Analytics**: Firebase Analytics
-- **Push Notifications**: Firebase Cloud Messaging
-- **Remote Config**: Firebase Remote Config
-- **CI/CD**: GitHub Actions
+- **Build system**: Gradle (Kotlin DSL + Version Catalog)
+- **JDK target**: 17
+- **Android SDKs**:
+  - `minSdk = 21`
+  - `targetSdk = 36`
+  - `compileSdk = 36`
+- **UI**: XML views + ViewBinding (Compose currently disabled)
+- **Local persistence**: Room
+- **Background jobs**: WorkManager
+- **Networking**: Retrofit + OkHttp + Moshi
+- **Observability/analytics**: Sentry + Firebase Analytics
+- **Mapping/geospatial integrations**: Mapbox + Location services
+- **Quality tooling**: Android Lint, Detekt, SonarQube
 
-## Development
+---
+
+## Project structure
+
+```text
+.
+├── app/                         # Android application module
+│   ├── src/main/java/com/akilimo/mobile/
+│   │   ├── ui/                  # Activities, fragments, dialogs, reusable UI components
+│   │   ├── workers/             # Domain sync/background workers and scheduling
+│   │   ├── base/                # Base classes and worker abstractions
+│   │   ├── repos/               # Repository layer over DAOs / local entities
+│   │   ├── dao/, entities/      # Room DAOs and entity models
+│   │   ├── network/, rest/      # API clients, DTOs, request/response models
+│   │   └── config/              # Runtime configuration helpers
+│   └── src/main/res/            # Android resources (layouts, strings, themes, drawables)
+├── docs/                        # Project documentation
+├── scripts/                     # Utility scripts (release notes generation)
+├── release/distribution/        # WhatsNew assets for Play Store release notes
+└── .github/workflows/           # CI/CD pipelines
+```
+
+---
+
+## Getting started
 
 ### Prerequisites
 
-- Android Studio Arctic Fox (2021.3.1) or newer
-- JDK 17
-- Android SDK 34
+- **Android Studio**: latest stable recommended
+- **JDK**: 17
+- **Android SDK**: API 36 platform + build tools
+- **Git**
 
-### Code Quality
-
-This project uses several tools to maintain code quality:
-
-- **SonarQube**: For code quality analysis
-- **Detekt**: For Kotlin static code analysis
-- **JaCoCo**: For code coverage reporting
-
-### Testing
-
-Run the tests with:
+### Clone
 
 ```bash
-./gradlew test
+git clone https://github.com/IITA-AKILIMO/akilimo-mobile.git
+cd akilimo-mobile
 ```
 
-For UI tests:
+### Open in Android Studio
+
+1. Open the project root in Android Studio.
+2. Let Gradle sync.
+3. Ensure the IDE is using JDK 17.
+
+---
+
+## Configuration and secrets
+
+This project relies on a combination of Gradle properties, environment variables, and service JSON files.
+
+### 1) Gradle properties
+
+The build expects `MAPBOX_DOWNLOADS_TOKEN` for Mapbox Maven dependency resolution.
+
+Recommended approach:
+
+- Put secrets in `~/.gradle/gradle.properties` (preferred for local development), not in committed files.
+
+```properties
+MAPBOX_DOWNLOADS_TOKEN=<your-mapbox-download-token>
+```
+
+### 2) BuildConfig base URLs (optional overrides)
+
+`app/build.gradle.kts` reads optional environment variables:
+
+- `AKILIMO_BASE_URL`
+- `FUELROD_BASE_URL`
+
+If unset, default values are used.
+
+Example local override for a shell session:
 
 ```bash
-./gradlew connectedAndroidTest
+export AKILIMO_BASE_URL="https://api.akilimo.org"
+export FUELROD_BASE_URL="https://akilimo.fuelrod.com"
 ```
 
-## Release Process
+### 3) Firebase config
 
-The project uses GitHub Actions for automated releases to the Google Play Store. The workflow is
-defined in `.github/workflows/android.yml`.
+The app uses `app/google-services.json` for Firebase services.
 
-### Release Notes Generation
+If using a different Firebase project, replace with your environment-appropriate config.
 
-Release notes are automatically generated during the build process:
+### 4) Signing credentials (release builds)
 
-1. Update the `CHANGELOG.md` file with details of your changes following the established format
-2. The GitHub Actions workflow will:
-    - Extract the latest version information from `CHANGELOG.md`
-    - Generate release notes in English and Swahili
-    - Include these notes in both the Google Play Store release and GitHub release
+CI handles release signing via GitHub secrets. For local release signing, configure a local keystore and matching signing settings/workflow inputs.
 
-### Manual Release
+---
 
-If you need to manually generate release notes:
+## Build and run
+
+### Debug build
 
 ```bash
-python .github/scripts/generate_release_notes.py
+./gradlew assembleDebug
 ```
 
-This will create release notes files in the `distribution/whatsnew/` directory based on the latest
-entry in `CHANGELOG.md`.
+### Install to connected device/emulator
 
-## Tools
+```bash
+./gradlew installDebug
+```
 
-- https://pypi.org/project/ai-gen-commit/
+### Release artifacts (unsigned/signed depending on env)
 
-## Contributing
+```bash
+./gradlew assembleRelease bundleRelease
+```
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+---
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+## Testing and quality checks
 
-## License
+### Unit tests
 
-This project is licensed under the terms specified in the [LICENSE.md](LICENSE.md) file.
+```bash
+./gradlew testDebugUnitTest
+```
 
-## Contact
+### Instrumented tests (requires emulator/device)
 
-International Institute of Tropical Agriculture (
-IITA) - [https://www.iita.org/](https://www.iita.org/)
+```bash
+./gradlew connectedDebugAndroidTest
+```
 
-Project
-Link: [https://github.com/IITA-AKILIMO/akilimo-mobile](https://github.com/IITA-AKILIMO/akilimo-mobile)
+### Lint + static analysis
+
+```bash
+./gradlew lintDebug detekt
+```
+
+### Sonar task (depends on lint + detekt per Gradle setup)
+
+```bash
+./gradlew sonar
+```
+
+---
+
+## Release workflow
+
+The GitHub Actions workflow in `.github/workflows/android.yml` covers:
+
+1. Version/tag derivation
+2. Build APK/AAB
+3. Signing
+4. Artifact packaging
+5. Play Store publish (beta/production track logic)
+6. Post-publish build number update
+
+Release note source files are under:
+
+- `release/distribution/whatsnew/`
+
+Changelog history is maintained in:
+
+- `CHANGELOG.md`
+
+For script details, see `scripts/README.md`.
+
+---
+
+## Troubleshooting
+
+### Gradle cannot resolve Mapbox artifacts
+
+- Ensure `MAPBOX_DOWNLOADS_TOKEN` is set in a Gradle properties file available to Gradle.
+
+### Build runs with wrong Java version
+
+- Confirm Android Studio and/or `JAVA_HOME` points to JDK 17.
+
+### API endpoint confusion in debug builds
+
+- Verify environment variables for `AKILIMO_BASE_URL` and `FUELROD_BASE_URL`.
+- Check runtime configuration behavior in `AppConfig` and session overrides.
+
+### Slow UI operations involving DB
+
+- The current Room setup still allows main-thread queries for compatibility during migration phases. Prefer refactoring data access paths toward background/coroutine execution where possible.
+
+---
+
+## Documentation index
+
+- [Developer Guide](docs/DEVELOPMENT.md)
+- [Architecture Notes](docs/ARCHITECTURE.md)
+- [Technical Evaluation](docs/TECHNICAL_EVALUATION.md)
+- [Release Script Notes](scripts/README.md)
+- [Changelog](CHANGELOG.md)
+
+---
+
+## Maintainers and organization
+
+This project is maintained by/for AKILIMO under IITA initiatives.
+
+- IITA: <https://www.iita.org/>
+- Repository: <https://github.com/IITA-AKILIMO/akilimo-mobile>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,66 @@
+# AKILIMO Mobile Architecture Notes
+
+This document describes the current practical architecture implemented in the Android codebase.
+
+## 1. High-level architecture
+
+The app follows a layered Android architecture centered around:
+
+- **UI layer**: activities/fragments/dialogs/components
+- **Domain/persistence layer**: repositories over Room DAOs/entities
+- **Integration layer**: Retrofit APIs + request/response mapping
+- **Sync layer**: WorkManager workers for background hydration/synchronization
+
+## 2. Startup behavior
+
+`AkilimoApp` performs early app initialization:
+
+1. Starts network monitoring.
+2. Initializes locale support.
+3. Runs startup housekeeping.
+4. Schedules one-time/chained workers for reference data sync.
+
+This pattern supports offline-first workflows by hydrating local data soon after launch.
+
+## 3. Data flow patterns
+
+Typical read/write pattern:
+
+1. UI captures user input.
+2. Repository persists/retrieves local entities through DAO.
+3. Network calls are made through API service wrappers when needed.
+4. Workers refresh reference data in background and upsert into local DB.
+
+## 4. Background work
+
+Work orchestration is centralized in `WorkerScheduler`:
+
+- One-time unique work
+- Periodic unique work
+- Chained two-step work
+
+Default constraints require network connectivity.
+
+## 5. Network stack
+
+`ApiClient` configures:
+
+- Moshi serialization (including `LocalDateAdapter`)
+- OkHttp with retry/network interceptors
+- Conditional debug logging interceptor
+- Legacy TLS compatibility handling for older Android versions
+
+## 6. Configuration resolution
+
+Service base URLs are resolved via `AppConfig` using priority:
+
+1. Session override (if present)
+2. BuildConfig default from Gradle/environment
+
+This allows controlled runtime endpoint switching while preserving safe defaults.
+
+## 7. Known technical debt hotspots
+
+- Room currently allows main-thread queries (`allowMainThreadQueries()`), which should be removed during DB threading hardening.
+- Automated tests are currently limited relative to feature surface.
+- Some legacy and modern patterns coexist; progressive standardization is recommended per touched feature.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,81 @@
+# AKILIMO Mobile Developer Guide
+
+This guide is focused on day-to-day engineering work: local setup, common commands, coding expectations, and safe change practices.
+
+## 1. Local setup checklist
+
+1. Install Android Studio (latest stable).
+2. Install/configure JDK 17.
+3. Ensure Android SDK 36 and build tools are installed.
+4. Configure `MAPBOX_DOWNLOADS_TOKEN` in `~/.gradle/gradle.properties`.
+5. Open project in Android Studio and run Gradle sync.
+
+## 2. Common Gradle commands
+
+### Build
+
+```bash
+./gradlew assembleDebug
+./gradlew assembleRelease bundleRelease
+```
+
+### Tests
+
+```bash
+./gradlew testDebugUnitTest
+./gradlew connectedDebugAndroidTest
+```
+
+### Quality checks
+
+```bash
+./gradlew lintDebug
+./gradlew detekt
+./gradlew sonar
+```
+
+## 3. Runtime configuration
+
+Build-time defaults can be overridden through environment variables:
+
+- `AKILIMO_BASE_URL`
+- `FUELROD_BASE_URL`
+
+These become `BuildConfig` fields and are then resolved through `AppConfig` (session value first, then build fallback).
+
+## 4. Code organization conventions
+
+Main package root:
+
+- `ui/` for screens and visual components
+- `repos/` for persistence access wrappers
+- `dao/` + `entities/` for Room persistence
+- `workers/` for background sync orchestration
+- `network/` + `rest/` for remote calls and transport models
+
+When adding new features:
+
+1. Prefer adding new flow logic in feature-specific UI/activity packages.
+2. Keep networking concerns inside API/service + request/response models.
+3. Persist user/reference data through repos + DAOs.
+4. Reuse worker abstractions for paged sync work.
+
+## 5. Database and threading note
+
+`AppDatabase` currently uses `allowMainThreadQueries()` as a transitional behavior. Avoid introducing new main-thread DB operations; prefer background execution and coroutine-based data access patterns.
+
+## 6. Recommended pre-PR checklist
+
+Before opening a PR:
+
+1. Run `./gradlew lintDebug detekt testDebugUnitTest`.
+2. Verify impacted flow on emulator/device if UI behavior changed.
+3. Update docs when behavior/config changes.
+4. Add changelog entry when required by release process.
+
+## 7. Release-related references
+
+- Main pipeline: `.github/workflows/android.yml`
+- Changelog: `CHANGELOG.md`
+- Release note assets: `release/distribution/whatsnew/`
+- Script docs: `scripts/README.md`


### PR DESCRIPTION
### Motivation
- Bring the repository documentation up-to-date with the current codebase, build configuration and CI/release workflows to improve onboarding and reduce confusion.
- Provide a clear developer handbook and architecture overview so contributors can follow common setup, build, and design patterns consistently.
- Surface known technical debt and troubleshooting guidance (for example, the Room main-thread queries note) so teams can prioritize follow-ups.

### Description
- Rewrote `README.md` with a comprehensive project guide that includes updated technical baseline, getting-started steps, configuration/secrets guidance, build/test commands, CI/release notes, troubleshooting, and a documentation index.
- Added `docs/DEVELOPMENT.md` containing a developer-focused handbook with local setup checklist, common Gradle commands, runtime configuration notes, code-organization conventions, DB/threading guidance, and a pre-PR checklist.
- Added `docs/ARCHITECTURE.md` describing the app’s layered architecture, startup initialization and sync model, data flow patterns, worker scheduling strategy, network stack, configuration resolution, and known technical debt hotspots.
- This is documentation-only work and does not change runtime application logic or behavior (modified/added files: `README.md`, `docs/DEVELOPMENT.md`, `docs/ARCHITECTURE.md`).

### Testing
- Attempted a local Gradle sanity check via the wrapper (`./gradlew -q help`) to validate build metadata, but the wrapper execution was blocked by permission issues and then failed to bootstrap dependencies due to a network proxy error (`HTTP/1.1 403 Forbidden`).
- No unit or integration tests were executed as part of this docs-only change due to the CI/network constraints described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d90edda08832b829c97033ad0573e)
