### PR TITLE
docs: add usage guide for scripts README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,48 @@
+# Scripts
+
+This directory contains utility scripts used by the AKILIMO mobile project.
+
+## `generate_release_notes.py`
+
+Generates Play Store “What’s New” text from Git history and writes the output to:
+
+- `release/distribution/whatsnew/whatsnew-en-GB`
+- `release/distribution/whatsnew/whatsnew-sw`
+
+By default, the script:
+
+- Detects the latest relevant Git tag range automatically.
+- Uses Ollama to draft concise release notes in English (UK) and Swahili.
+- Enforces Play Store-friendly output length (max 500 characters).
+
+### Requirements
+
+- Python 3.12+
+- A Git repository with tags
+- (Optional) Ollama running locally or remotely if AI generation is enabled
+
+### Usage
+
+Run from the repository root:
+
+```bash
+python3 scripts/generate_release_notes.py
+```
+
+Useful options:
+
+```bash
+# Generate notes for a specific tag
+python3 scripts/generate_release_notes.py --tag v1.2.3
+
+# Skip AI generation and use fallback text
+python3 scripts/generate_release_notes.py --no-ai
+
+# Override the Ollama model
+python3 scripts/generate_release_notes.py --model gemma3
+```
+
+### Environment variables
+
+- `OLLAMA_HOST` (default: `http://localhost:11434`)
+- `OLLAMA_MODEL` (default: `gemma3`)


### PR DESCRIPTION
### Motivation
- Provide developers with clear guidance on the repository's utility scripts so the release notes generator is discoverable and easy to run.
- Document expected outputs, prerequisites, and environment configuration to prevent confusion when generating Play Store release notes.

### Description
- Add `scripts/README.md` describing the purpose of the `scripts` directory and the `generate_release_notes.py` tool.
- Document output locations: `release/distribution/whatsnew/whatsnew-en-GB` and `release/distribution/whatsnew/whatsnew-sw`.
- Include requirements, usage examples, CLI options (`--tag`, `--no-ai`, `--model`), and environment variables (`OLLAMA_HOST`, `OLLAMA_MODEL`).

### Testing
- Ran `python3 scripts/generate_release_notes.py --help` and verified the CLI help output was displayed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d93641418832b830e8a4e88b5eae4)
