### PR TITLE
fix(MUN-16): language selection does not persist — normalize BCP-47 codes

### DIFF
--- a/app/src/main/java/com/akilimo/mobile/AkilimoApp.kt
+++ b/app/src/main/java/com/akilimo/mobile/AkilimoApp.kt
@@ -127,9 +127,7 @@ class AkilimoApp : MultiDexApplication(), Configuration.Provider {
         // saved by SessionManager so the two sources stay in sync after a language change.
         val locale = appLocaleRepo.desiredLocale
             ?: run {
-                val savedTag = SessionManager.get(this).languageCode
-                    .takeIf { it.isNotBlank() }
-                    ?: Locales.english.toLanguageTag()
+                val savedTag = Locales.normalize(SessionManager.get(this).languageCode)
                 Locales.supportedLocales.find { it.toLanguageTag() == savedTag }
                     ?: Locales.english
             }

--- a/app/src/main/java/com/akilimo/mobile/Locales.kt
+++ b/app/src/main/java/com/akilimo/mobile/Locales.kt
@@ -14,4 +14,17 @@ object Locales {
         swahili,
         kinyarwanda,
     )
+
+    /**
+     * Converts any stored language code (old short codes like "en", "sw", "rw" or full
+     * BCP-47 tags like "en-US") to the canonical BCP-47 tag used by the app.
+     * Falls back to English if the code is unrecognised.
+     */
+    fun normalize(code: String): String {
+        if (code.isBlank()) return english.toLanguageTag()
+        return supportedLocales
+            .find { it.toLanguageTag().equals(code, ignoreCase = true) || it.language.equals(code, ignoreCase = true) }
+            ?.toLanguageTag()
+            ?: english.toLanguageTag()
+    }
 }

--- a/app/src/main/java/com/akilimo/mobile/entities/UserPreferences.kt
+++ b/app/src/main/java/com/akilimo/mobile/entities/UserPreferences.kt
@@ -14,7 +14,7 @@ data class UserPreferences(
     val id: Int = 1,
 
     @ColumnInfo(name = "language_code")
-    val languageCode: String = "en",
+    val languageCode: String = "en-US",
 
     @ColumnInfo(name = "first_name")
     val firstName: String? = null,

--- a/app/src/main/java/com/akilimo/mobile/ui/viewmodels/UserSettingsViewModel.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/viewmodels/UserSettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.akilimo.mobile.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.akilimo.mobile.Locales
 import com.akilimo.mobile.entities.AkilimoUser
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -32,7 +33,8 @@ class UserSettingsViewModel @Inject constructor(
 
     fun loadPreferences() = viewModelScope.launch {
         val prefs = prefsRepo.getOrDefault()
-        _uiState.update { it.copy(preferences = prefs) }
+        val normalized = prefs.copy(languageCode = Locales.normalize(prefs.languageCode))
+        _uiState.update { it.copy(preferences = normalized) }
     }
 
     fun savePreferences(preferences: UserPreferences, userName: String, previousLangCode: String) =

--- a/app/src/main/java/com/akilimo/mobile/ui/viewmodels/WelcomeViewModel.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/viewmodels/WelcomeViewModel.kt
@@ -2,6 +2,7 @@ package com.akilimo.mobile.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.akilimo.mobile.Locales
 import com.akilimo.mobile.dto.LanguageOption
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -28,8 +29,8 @@ class WelcomeViewModel @Inject constructor(
     fun loadLanguage(userName: String) = viewModelScope.launch {
         val user = userRepo.getUser(userName)
         val prefs = prefsRepo.getOrDefault()
-        val code = user?.languageCode?.takeIf { it.isNotBlank() } ?: prefs.languageCode
-        _uiState.update { it.copy(currentLanguageCode = code) }
+        val raw = user?.languageCode?.takeIf { it.isNotBlank() } ?: prefs.languageCode
+        _uiState.update { it.copy(currentLanguageCode = Locales.normalize(raw)) }
     }
 
     fun saveLanguage(selected: LanguageOption, userName: String) = viewModelScope.launch {


### PR DESCRIPTION
## Summary

- **Root cause**: `UserPreferences.languageCode` defaulted to `"en"` (short code) but the language dropdown options are keyed on full BCP-47 tags (`"en-US"`, `"sw-TZ"`, `"rw-RW"`). The exact-match lookup in `UserSettingsActivity` always returned null, showing an **empty language dropdown** for all existing users; selecting a language and saving also triggered a spurious restart even when the language hadn't changed.
- **`Locales.normalize(code)`**: new helper that maps any short code or BCP-47 tag to the canonical app-supported tag, falls back to English.
- **`UserPreferences.languageCode` default**: `"en"` → `"en-US"` so newly created rows are immediately consistent.
- **`WelcomeViewModel` + `UserSettingsViewModel`**: normalize raw DB value before emitting to UI state.
- **`AkilimoApp.initLocale()`**: normalize the SessionManager fallback so old installs that stored `"en"` or `"sw"` still find the right locale.

## Test plan

- [x] Fresh install: language dropdown in both WelcomeFragment and UserSettingsActivity shows "English" pre-selected (not empty)
- [x] Select "Swahili" → confirm restart prompt → app restarts in Swahili
- [x] Kill + reopen app: Swahili still active
- [x] Open UserSettingsActivity: language dropdown shows "Swahili" (not empty)
- [x] Change language back to English → restart → English active
- [x] Old install (upgrade): language dropdown no longer shows empty; resolves to previously selected language

🤖 Generated with [Claude Code](https://claude.com/claude-code)