### PR TITLE
👷 ci: make gradlew executable and rename workflow

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,4 @@
-name: Android Unit Tests (Extreme)
+name: Unit Tests
 
 on:
   workflow_run:
@@ -33,6 +33,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: false
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
 
       # ⚡ AVOID CONFIGURATION OVERHEAD
       - name: Run only affected tests


### PR DESCRIPTION
Grant execution permissions to the Gradle wrapper to prevent runner
failures and simplify the workflow name for better visibility.
