### PR TITLE
fix/ui

### DIFF
--- a/app/src/main/java/com/akilimo/mobile/base/BaseActivity.kt
+++ b/app/src/main/java/com/akilimo/mobile/base/BaseActivity.kt
@@ -20,12 +20,13 @@ import androidx.viewbinding.ViewBinding
 import com.akilimo.mobile.AkilimoApp
 import com.akilimo.mobile.AppDatabase
 import com.akilimo.mobile.data.AppSettingsDataStore
+import com.akilimo.mobile.data.AppSettingsEntryPoint
 import com.akilimo.mobile.helper.LocaleHelper
 import com.akilimo.mobile.interfaces.DefaultDispatcherProvider
-import javax.inject.Inject
 import com.akilimo.mobile.interfaces.IDispatcherProvider
 import com.akilimo.mobile.ui.components.NetworkNotificationView
 import com.akilimo.mobile.utils.PermissionHelper
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.launch
 
 abstract class BaseActivity<VB : ViewBinding> : AppCompatActivity() {
@@ -34,10 +35,14 @@ abstract class BaseActivity<VB : ViewBinding> : AppCompatActivity() {
         const val COMPLETED_TASK = "completed_task"
     }
 
-    @Inject lateinit var appSettings: AppSettingsDataStore
+    /** Accessed via Hilt EntryPoint so base classes need no @Inject and have no lateinit timing risk. */
+    protected val sessionManager: AppSettingsDataStore by lazy {
+        EntryPointAccessors.fromApplication(applicationContext, AppSettingsEntryPoint::class.java)
+            .appSettings()
+    }
 
-    /** Backward-compatible alias — all existing call sites keep working unchanged. */
-    protected val sessionManager get() = appSettings
+    /** Alias kept so call sites that reference appSettings directly still compile. */
+    protected val appSettings get() = sessionManager
 
     protected val dispatcherProvider: IDispatcherProvider = DefaultDispatcherProvider()
 

--- a/app/src/main/java/com/akilimo/mobile/base/BaseFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/base/BaseFragment.kt
@@ -13,18 +13,23 @@ import androidx.lifecycle.lifecycleScope
 import androidx.viewbinding.ViewBinding
 import com.akilimo.mobile.AppDatabase
 import com.akilimo.mobile.data.AppSettingsDataStore
+import com.akilimo.mobile.data.AppSettingsEntryPoint
+import dagger.hilt.android.EntryPointAccessors
 import timber.log.Timber
-import javax.inject.Inject
 
 abstract class BaseFragment<VB : ViewBinding> : Fragment() {
 
     private var _binding: VB? = null
     protected val binding get() = _binding!!
 
-    @Inject lateinit var appSettings: AppSettingsDataStore
+    /** Accessed via Hilt EntryPoint so base classes need no @Inject and have no lateinit timing risk. */
+    protected val sessionManager: AppSettingsDataStore by lazy {
+        EntryPointAccessors.fromApplication(requireContext().applicationContext, AppSettingsEntryPoint::class.java)
+            .appSettings()
+    }
 
-    /** Backward-compatible alias — all existing call sites keep working unchanged. */
-    protected val sessionManager get() = appSettings
+    /** Alias kept so call sites that reference appSettings directly still compile. */
+    protected val appSettings get() = sessionManager
 
     protected lateinit var database: AppDatabase
 

--- a/app/src/main/java/com/akilimo/mobile/data/AppSettingsEntryPoint.kt
+++ b/app/src/main/java/com/akilimo/mobile/data/AppSettingsEntryPoint.kt
@@ -1,0 +1,11 @@
+package com.akilimo.mobile.data
+
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface AppSettingsEntryPoint {
+    fun appSettings(): AppSettingsDataStore
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/activities/LocationPickerActivity.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/activities/LocationPickerActivity.kt
@@ -35,6 +35,7 @@ import com.mapbox.maps.plugin.locationcomponent.location
 import io.sentry.Sentry
 import kotlinx.coroutines.launch
 import dagger.hilt.android.AndroidEntryPoint
+import com.akilimo.mobile.BuildConfig
 
 @AndroidEntryPoint
 class LocationPickerActivity : BaseActivity<ActivityLocationPickerBinding>() {
@@ -64,7 +65,9 @@ class LocationPickerActivity : BaseActivity<ActivityLocationPickerBinding>() {
 
     override fun attachBaseContext(newBase: Context) {
         super.attachBaseContext(newBase)
-        com.mapbox.common.MapboxOptions.accessToken = sessionManager.mapBoxApiKey
+        // Use the build-time token here — Hilt is not yet injected in attachBaseContext.
+        // sessionManager.mapBoxApiKey falls back to this same value anyway.
+        com.mapbox.common.MapboxOptions.accessToken = BuildConfig.MAPBOX_RUNTIME_TOKEN
     }
 
     override fun inflateBinding() = ActivityLocationPickerBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/akilimo/mobile/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/activities/MainActivity.kt
@@ -34,8 +34,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
     }
 
     override fun onBindingReady(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/akilimo/mobile/ui/usecases/CassavaMarketActivity.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/usecases/CassavaMarketActivity.kt
@@ -37,6 +37,7 @@ class CassavaMarketActivity : BaseActivity<ActivityCassavaMarketBinding>() {
     private lateinit var cassavaUnitAdapter: CassavaUnitAdapter
 
     private var isGridLayout = false
+    private var initialChoiceApplied = false
     private val gridSpanCount by lazy { resources.getInteger(R.integer.grid_span_count_default) }
 
     override fun inflateBinding() = ActivityCassavaMarketBinding.inflate(layoutInflater)
@@ -85,6 +86,10 @@ class CassavaMarketActivity : BaseActivity<ActivityCassavaMarketBinding>() {
 
         factoryAdapter.onItemClick = { factory ->
             viewModel.selectFactory(factory)
+            val updatedList = factoryAdapter.currentList.map { item ->
+                item.copy().apply { isSelected = item.id == factory.id }
+            }
+            factoryAdapter.submitList(updatedList)
         }
 
         cassavaUnitAdapter.onItemClick = { unit ->
@@ -153,13 +158,19 @@ class CassavaMarketActivity : BaseActivity<ActivityCassavaMarketBinding>() {
                     binding.swipeRefreshFactories.isRefreshing = state.factoriesRefreshing
                     binding.swipeRefreshUnits.isRefreshing = state.unitsRefreshing
 
-                    // Apply initial radio selection once (only when choice is known)
-                    when (state.initialMarketChoice) {
-                        CassavaMarketViewModel.MarketChoice.FACTORY ->
-                            binding.rgMarketChoice.check(R.id.rb_sell_to_factory)
-                        CassavaMarketViewModel.MarketChoice.MARKET ->
-                            binding.rgMarketChoice.check(R.id.rb_sell_to_market)
-                        CassavaMarketViewModel.MarketChoice.NONE -> Unit
+                    // Apply initial radio selection exactly once
+                    if (!initialChoiceApplied) {
+                        when (state.initialMarketChoice) {
+                            CassavaMarketViewModel.MarketChoice.FACTORY -> {
+                                binding.rgMarketChoice.check(R.id.rb_sell_to_factory)
+                                initialChoiceApplied = true
+                            }
+                            CassavaMarketViewModel.MarketChoice.MARKET -> {
+                                binding.rgMarketChoice.check(R.id.rb_sell_to_market)
+                                initialChoiceApplied = true
+                            }
+                            CassavaMarketViewModel.MarketChoice.NONE -> Unit
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/akilimo/mobile/ui/viewmodels/CassavaMarketViewModel.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/viewmodels/CassavaMarketViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -68,25 +69,31 @@ class CassavaMarketViewModel @Inject constructor(
         }
 
         launch {
-            factoryRepo.observeAll().collectLatest { factories ->
-                val details = selectedRepo.getSelectedByUser(userId)
-                val mapped = factories.map {
+            combine(
+                factoryRepo.observeAll(),
+                selectedRepo.observeSelected(userId)
+            ) { factories, details ->
+                factories.map {
                     StarchFactory(id = it.id, name = it.name, label = it.label).apply {
                         isSelected = it.id == details?.selectedCassavaMarket?.starchFactoryId
                     }
                 }
+            }.collectLatest { mapped ->
                 _uiState.update { it.copy(factories = mapped, factoriesRefreshing = false) }
             }
         }
 
         launch {
-            cassavaUnitRepo.observeAll().collectLatest { units ->
-                val details = selectedRepo.getSelectedByUser(userId)
-                val mapped = units.map { unit ->
+            combine(
+                cassavaUnitRepo.observeAll(),
+                selectedRepo.observeSelected(userId)
+            ) { units, details ->
+                units.map { unit ->
                     CassavaUnit(id = unit.id, label = unit.label, description = unit.description).apply {
                         isSelected = unit.id == details?.selectedCassavaMarket?.cassavaUnitId
                     }
                 }
+            }.collectLatest { mapped ->
                 _uiState.update { it.copy(cassavaUnits = mapped, unitsRefreshing = false) }
             }
         }
@@ -95,6 +102,13 @@ class CassavaMarketViewModel @Inject constructor(
     fun selectFactory(factory: StarchFactory) = viewModelScope.launch {
         val userId = _uiState.value.userId
         selectedRepo.select(SelectedCassavaMarket(userId = userId, starchFactoryId = factory.id))
+        _uiState.update { state ->
+            state.copy(
+                factories = state.factories.map { f ->
+                    f.copy().apply { isSelected = f.id == factory.id }
+                }
+            )
+        }
     }
 
     fun saveSelectedPrice(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,16 +6,16 @@ This document describes the architecture implemented in the Android codebase.
 
 ## 1. High-Level Architecture
 
-The app follows a layered MVVM-adjacent architecture. There are no explicit `ViewModel` classes — fragment/activity classes interact directly with repositories through coroutine scopes.
+The app follows a layered MVVM-adjacent architecture. ViewModels exist for key screens (`WelcomeViewModel`, `UserSettingsViewModel`); remaining fragments/activities still interact directly with repositories through coroutine scopes.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                        PRESENTATION LAYER                        │
 │  HomeStepperActivity  UserSettingsActivity  [20+ Activities]     │
-│   └─ StepperAdapter → [WelcomeFragment … SummaryFragment]        │
+│   └─ WizardAdapter (ViewPager2) → [WelcomeFragment … Summary]   │
 │  BaseActivity<VB>  →  attachBaseContext  →  LocaleHelper.wrap()  │
 │  BaseFragment<VB>  →  safeScope (lifecycleScope)                 │
-│  BaseStepFragment<VB>  →  Step interface  →  prefillFromEntity() │
+│  BaseStepFragment<VB>  →  WizardStep interface → prefillFromEntity() │
 └────────────────────────────┬────────────────────────────────────┘
                              │ suspend / safeScope.launch
 ┌────────────────────────────▼────────────────────────────────────┐
@@ -36,7 +36,10 @@ The app follows a layered MVVM-adjacent architecture. There are no explicit `Vie
            │
 ┌──────────▼─────────────────────────────────────────────────────┐
 │                      CROSS-CUTTING                              │
-│  SessionManager  — SharedPrefs singleton ("new-akilimo-config") │
+│  AppSettingsDataStore — Preferences DataStore, 17 keys,        │
+│    migrated from SharedPrefs ("new-akilimo-config")             │
+│  Hilt DI (2.57.1) — @HiltAndroidApp / @AndroidEntryPoint /    │
+│    @HiltViewModel; kapt for Hilt compiler                       │
 │  NetworkMonitor  — StateFlow<Boolean> connectivity              │
 │  WorkManager     — FertilizerWorker, CassavaPriceWorker, etc.   │
 │  Sentry 8.23 + Firebase Analytics — observability              │
@@ -50,19 +53,21 @@ The app follows a layered MVVM-adjacent architecture. There are no explicit `Vie
 
 ```
 com.akilimo.mobile/
-├── AkilimoApp.kt             Application: locale init, WorkManager, NetworkMonitor
+├── AkilimoApp.kt             Application: @HiltAndroidApp, locale init, WorkManager, NetworkMonitor
 ├── AppDatabase.kt            Room singleton (17 entities, v2, KSP)
 ├── Locales.kt                Supported locales: en-US, sw-TZ, rw-RW
 ├── base/
-│   ├── BaseActivity.kt       attachBaseContext → LocaleHelper, network/permission setup
-│   ├── BaseFragment.kt       safeScope, DB, SessionManager access
-│   └── BaseStepFragment.kt   Step interface; onSelected() → prefillFromEntity()
+│   ├── BaseActivity.kt       attachBaseContext → AppSettingsDataStore.readLanguageTagSync(); network/permission setup
+│   ├── BaseFragment.kt       safeScope, DB, appSettings (AppSettingsDataStore) access
+│   └── BaseStepFragment.kt   WizardStep interface; onSelected() → prefillFromEntity()
+├── data/
+│   └── AppSettingsDataStore.kt  Preferences DataStore; 17 settings keys; SharedPreferencesMigration from "new-akilimo-config"
 ├── helper/
-│   ├── SessionManager.kt     SharedPrefs singleton, languageCode, tokens, flags
 │   └── LocaleHelper.kt       createConfigurationContext() wrapper for locale application
 ├── ui/
 │   ├── activities/           HomeStepperActivity (launcher), UserSettingsActivity, 18+ domain activities
-│   └── fragments/            WelcomeFragment … SummaryFragment (11 stepper steps)
+│   ├── fragments/            WelcomeFragment … SummaryFragment (11 stepper steps)
+│   └── viewmodels/           WelcomeViewModel, UserSettingsViewModel (key screens)
 ├── repos/                    Typed repository classes wrapping Room DAOs
 ├── dao/                      Room @Dao interfaces
 ├── entities/                 Room @Entity data classes
@@ -83,7 +88,7 @@ com.akilimo.mobile/
 `AkilimoApp.onCreate()` runs on process start in this order:
 
 1. `networkMonitor.startMonitoring()` — begins StateFlow connectivity tracking
-2. `initLocale()` — reads saved locale from `SharedPrefsAppLocaleRepository`; falls back to `SessionManager.languageCode`; sets `AppLocale.desiredLocale`
+2. `initLocale()` — reads saved locale tag via `appSettings.getLanguageTagSync()`; sets `AppLocale.desiredLocale` and `AppCompatDelegate.setApplicationLocales()`
 3. `initVectorSupport()` — enables vector drawables on pre-21 (compatibility)
 4. `initTimeAndCountry()` — initializes `World` (country data library)
 5. `runStartupTasks()` — `StartupManager.runHousekeeping()`
@@ -91,8 +96,8 @@ com.akilimo.mobile/
 7. Schedules chained workers: `FertilizerWorker` → `FertilizerPriceWorker`
 
 Each `Activity.onCreate()`:
-1. `attachBaseContext()` called first — reads `SessionManager.languageCode`, wraps context via `LocaleHelper.wrap()`
-2. `AppCompatDelegate.setDefaultNightMode(MODE_NIGHT_NO)` — forces light mode
+1. `attachBaseContext()` called first — reads locale tag via `AppSettingsDataStore.readLanguageTagSync(newBase)` (companion static), wraps context via `LocaleHelper.wrap()`
+2. `AppCompatDelegate.setDefaultNightMode()` — driven by `appSettings.darkMode`
 3. View binding inflated, `setContentView()` called
 4. `observeNetworkChanges()` — collects `NetworkMonitor.isConnected` via `repeatOnLifecycle(STARTED)`
 
@@ -130,29 +135,41 @@ SummaryFragment / GetRecommendationActivity
 
 ## 5. Locale / i18n System
 
-Three components work together:
+`AppSettingsDataStore` is the single source of truth for the user's language selection. `SessionManager` has been deleted.
 
-| Component | Role | SharedPrefs File |
-|-----------|------|-----------------|
-| `SessionManager.languageCode` | Persists user's language choice | `new-akilimo-config` |
-| `AppLocale.appLocaleRepository` (`SharedPrefsAppLocaleRepository`) | AppLocale library's own locale store | AppLocale internal |
-| `LocaleHelper.wrap(context, langTag)` | Applies locale to Activity context via `createConfigurationContext()` | — |
+| Component | Role |
+|-----------|------|
+| `AppSettingsDataStore.languageTag` | Persists BCP-47 language tag in Preferences DataStore (migrated from `"new-akilimo-config"` SharedPrefs) |
+| `AppCompatDelegate.setApplicationLocales(LocaleListCompat)` | Applies locale at runtime; recreates activities in-process — no process kill required |
+| `AppLocale.desiredLocale` | Set as a secondary step for the AppLocale string-replacement library |
+| `LocaleHelper.wrap(context, langTag)` | Applies locale to Activity context via `createConfigurationContext()` during `attachBaseContext()` |
 
 **Application flow on startup:**
 
 ```
 AkilimoApp.initLocale()
-  → reads SharedPrefsAppLocaleRepository.desiredLocale
-  → if null: falls back to SessionManager.languageCode
-  → sets AppLocale.desiredLocale
+  → appSettings.getLanguageTagSync()       → e.g. "sw-TZ"
+  → AppLocale.desiredLocale = …
+  → AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("sw-TZ"))
 
 BaseActivity.attachBaseContext(newBase)
-  → SessionManager.get(newBase).languageCode  → e.g. "sw-TZ"
+  → AppSettingsDataStore.readLanguageTagSync(newBase)   → e.g. "sw-TZ"
   → LocaleHelper.wrap(newBase, "sw-TZ")
        → Locale.Builder().setLanguageTag("sw-TZ").build()
        → config.setLocales(LocaleList(locale))
        → newBase.createConfigurationContext(config)
        → resolves values-sw-rTZ/strings.xml ✓
+```
+
+**Runtime language change (WelcomeFragment / UserSettingsActivity):**
+
+```
+safeScope.launch {
+    appSettings.setLanguageTag(tag)          // write to DataStore first (fixes race condition)
+    AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(tag))
+    AppLocale.desiredLocale = …              // secondary step for Reword library
+}
+// setApplicationLocales() triggers in-process activity recreation — no ProcessPhoenix needed
 ```
 
 **Supported locales** (defined in `Locales.kt`):
@@ -171,7 +188,7 @@ Navigation is purely intent-based — there is no Jetpack NavGraph.
 
 ```
 HomeStepperActivity (launcher)
-  └─ StepperAdapter → 11 step fragments (sequential)
+  └─ WizardAdapter (ViewPager2) → 11 step fragments (sequential, pendingOnSelected pattern)
        └─ SummaryFragment → startActivity(RecommendationsActivity)
   └─ FAB → startActivity(UserSettingsActivity)
 
@@ -204,7 +221,7 @@ Workers read from the network API and upsert data into Room using the repository
 - Timeout: 60 seconds (configurable per call site)
 
 Base URLs resolved via `AppConfig`:
-1. Session override (`SessionManager.akilimoEndpoint` / `fuelrodEndpoint`) if set
+1. DataStore override (`AppSettingsDataStore.readEndpointSync()` — `akilimoEndpoint` / `fuelrodEndpoint` keys) if set
 2. `BuildConfig.AKILIMO_BASE_URL` / `FUELROD_BASE_URL` as fallback
 
 ---
@@ -213,12 +230,12 @@ Base URLs resolved via `AppConfig`:
 
 | Mechanism | Scope | Usage |
 |-----------|-------|-------|
-| `SessionManager` (SharedPrefs) | Process lifetime | Language, tokens, flags, device ID |
+| `AppSettingsDataStore` (Preferences DataStore) | Process lifetime | Language tag, dark mode, tokens, flags, device ID, endpoints — 17 keys total |
 | Room entities | Persistent | User profile, preferences, reference data |
 | `NetworkMonitor.isConnected: StateFlow<Boolean>` | Process lifetime | Connectivity banner in BaseActivity |
 | `safeScope` (`lifecycleScope`) | Activity/Fragment lifecycle | All coroutine launches in UI layer |
 
-No `ViewModel` classes exist. Configuration changes (rotation) trigger full reload from Room/SharedPrefs.
+`AppSettingsDataStore` is injected via Hilt (`@Inject lateinit var appSettings: AppSettingsDataStore`) in `BaseActivity` and `BaseFragment`. A `protected val sessionManager get() = appSettings` alias exists for backward compatibility. ViewModels exist for key screens (`WelcomeViewModel`, `UserSettingsViewModel`); remaining screens still load directly from repositories.
 
 ---
 
@@ -228,12 +245,12 @@ No `ViewModel` classes exist. Configuration changes (rotation) trigger full relo
 |------|----------|------|--------|
 | `allowMainThreadQueries()` | `AppDatabase.kt` | ANR risk | ✅ Fixed |
 | `fallbackToDestructiveMigration()` | `AppDatabase.kt` | Data loss on schema change | ⬜ Open |
-| No ViewModel classes | All fragments/activities | State lost on configuration change | ⬜ Open |
-| API keys hardcoded in source | `SessionManager.kt` | Exposed in APK without obfuscation | ✅ Fixed |
+| No ViewModel classes (partial) | Most fragments/activities | State lost on configuration change | 🔄 Partial — key screens done |
+| API keys hardcoded in source | `app/build.gradle.kts`, `BuildConfig` | Exposed in APK without obfuscation | ✅ Fixed |
 | `isMinifyEnabled = false` in release | `app/build.gradle.kts` | No code shrinking or obfuscation | ⬜ Open |
 | No Jetpack NavGraph | All | Deep links impossible; navigation untestable | ⬜ Open |
-| No DI framework | All | Manual repo instantiation; untestable | ⬜ Open |
-| Dual SharedPrefs locale sources | `SessionManager` + `AppLocale` | Potential sync drift on cold start | ⬜ Open |
+| No DI framework | All | Manual repo instantiation; untestable | ✅ Fixed — Hilt 2.57.1 |
+| Dual SharedPrefs locale sources | `SessionManager` + `AppLocale` | Potential sync drift on cold start | ✅ Fixed — DataStore is sole source |
 
 ---
 
@@ -259,7 +276,7 @@ and its wiring change.
 │  @HiltViewModel — one per screen                                     │
 │  State: UiState data class exposed as StateFlow                      │
 │  Navigation: NavEvent sealed interface exposed as SharedFlow         │
-│  Injected: repos, SessionManager (via Hilt), DataStore              │
+│  Injected: repos, AppSettingsDataStore (via Hilt)                   │
 └──────────────────────────┬──────────────────────────────────────────┘
                             │ suspend / Flow (unchanged)
 ┌──────────────────────────▼──────────────────────────────────────────┐

--- a/docs/COMPOSE_MIGRATION.md
+++ b/docs/COMPOSE_MIGRATION.md
@@ -50,12 +50,12 @@ ROADMAP as items 3–14.
 | P3 | Enable R8 minification | Compose compiler generates significant bytecode; minification is required for release APK size | #5 |
 | P4 | Introduce ViewModels | Compose `collectAsStateWithLifecycle()` needs a ViewModel as the state holder; all screen state moves there | #7 |
 | P5 | Proper Room migrations | Schema changes during migration must not wipe user data | #8 |
-| P6 | **Introduce Hilt** | `hiltViewModel()` in composables; `@HiltAndroidApp`, `@AndroidEntryPoint` on host activities | #9 |
-| P7 | Consolidate language to DataStore | `rememberUpdatedState` needs a single reactive source; dual SharedPrefs causes recomposition race | #10 |
+| P6 | **Introduce Hilt** ✅ Done | `hiltViewModel()` in composables; `@HiltAndroidApp`, `@AndroidEntryPoint` on host activities | #9 |
+| P7 | Consolidate language + all settings to DataStore ✅ Done | `rememberUpdatedState` needs a single reactive source; dual SharedPrefs causes recomposition race | #10 |
 | P8 | Jetpack NavGraph | `NavHost` + `composable { }` destinations replace `startActivity()` calls | #13 |
 
-Do not skip P6 (Hilt) or P8 (NavGraph). Compose screens without Hilt require manual DI threading
-via CompositionLocals, which creates more tech debt than it removes.
+P6 (Hilt) is complete. Do not skip P8 (NavGraph). Compose screens without NavGraph require manual
+`startActivity()` calls from composables, which creates navigation debt.
 
 ---
 
@@ -70,12 +70,13 @@ The Compose BOM, `activity-compose`, and all core UI/Material3 compose library a
 **already present** in the catalog. The following entries are missing and must be added before
 Phase 1 begins.
 
-#### `[versions]` — add these three lines
+#### `[versions]` — current state and what still needs adding
+
+Hilt is already in the catalog at version `"2.57.1"`. The Compose BOM is already present at `"2025.10.00"`.
 
 ```toml
-# Compose / Hilt additions
+# Still missing — add these:
 navigationCompose      = "2.8.5"   # navigation-compose (separate from view-based navigation = "2.7.5")
-hilt                   = "2.54"
 hiltNavigationCompose  = "1.2.0"
 ```
 
@@ -86,22 +87,25 @@ hiltNavigationCompose  = "1.2.0"
 androidx-compose-material3-window    = { group = "androidx.compose.material3",   name = "material3-window-size-class" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle",            name = "lifecycle-viewmodel-compose",  version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-runtime-compose   = { group = "androidx.lifecycle",            name = "lifecycle-runtime-compose",    version.ref = "lifecycleRuntimeKtx" }
+# navigation-compose and hilt-navigation-compose are NOT yet in the catalog — add before Phase 1:
 androidx-navigation-compose          = { group = "androidx.navigation",           name = "navigation-compose",           version.ref = "navigationCompose" }
-hilt-android                         = { group = "com.google.dagger",             name = "hilt-android",                 version.ref = "hilt" }
-hilt-compiler                        = { group = "com.google.dagger",             name = "hilt-android-compiler",        version.ref = "hilt" }
 hilt-navigation-compose              = { group = "androidx.hilt",                 name = "hilt-navigation-compose",      version.ref = "hiltNavigationCompose" }
 ```
 
-#### `[plugins]` — uncomment `kotlin-compose` and add `hilt-android`
+> Note: `hilt-android` and `hilt-compiler` are already in the catalog (used by the current `kapt`-based Hilt integration).
+
+#### `[plugins]` — `kotlin-compose` still needs to be uncommented; `hilt` is already present
 
 ```toml
-# Change this line (currently commented out):
+# kotlin-compose is still commented out in the catalog — uncomment before Phase 1:
 #kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-# to:
+# change to:
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
-# Add this line:
-hilt-android   = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+# hilt plugin is already in the catalog as:
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+# and is applied in app/build.gradle.kts as:
+# alias(libs.plugins.hilt)
 ```
 
 #### `[bundles]` — optional convenience bundle (add alongside `androidx-navigation`)
@@ -126,10 +130,10 @@ compose-core = [
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)   // ← add (was commented out in catalog)
+    alias(libs.plugins.kotlin.compose)   // ← add when catalog entry is uncommented (Phase 1)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.hilt.android)     // ← add (requires prerequisite #9)
+    alias(libs.plugins.hilt)             // ← already active (was libs.plugins.hilt.android in old docs; correct alias is libs.plugins.hilt)
     // … existing plugins unchanged
 }
 ```
@@ -177,10 +181,10 @@ dependencies {
     // ── Navigation Compose ────────────────────────────────────────────────────
     implementation(libs.androidx.navigation.compose)            // ← new catalog entry
 
-    // ── Hilt (prerequisite #9) ────────────────────────────────────────────────
-    implementation(libs.hilt.android)                           // ← new catalog entry
-    ksp(libs.hilt.compiler)                                     // ← new catalog entry
-    implementation(libs.hilt.navigation.compose)                // ← new catalog entry
+    // ── Hilt (already integrated — prerequisite #9 ✅ Done) ──────────────────
+    implementation(libs.hilt.android)                           // already in build.gradle.kts
+    kapt(libs.hilt.compiler)                                    // uses kapt (not ksp) for Hilt compiler
+    implementation(libs.hilt.navigation.compose)                // ← new catalog entry (add before Phase 1)
 
     // ── Debug / test ─────────────────────────────────────────────────────────
     debugImplementation(libs.androidx.compose.ui.tooling)
@@ -464,7 +468,7 @@ data class UserSettingsUiState(
 @HiltViewModel
 class UserSettingsViewModel @Inject constructor(
     private val prefsRepo: UserPreferencesRepo,
-    private val sessionManager: SessionManager,
+    private val appSettings: AppSettingsDataStore,   // SessionManager is deleted; inject DataStore
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(UserSettingsUiState())
@@ -572,25 +576,18 @@ fun MapboxMapView(modifier: Modifier = Modifier) {
 
 Use this for `LocationPickerActivity`'s Mapbox map during Phase 3.
 
-### 6.3 Provide SessionManager and Database via CompositionLocal (pre-Hilt)
+### 6.3 CompositionLocal bridge — Hilt is now active, use @HiltViewModel
 
-If Hilt isn't integrated yet when a screen migrates, thread dependencies through
-CompositionLocals as a temporary measure:
+> **Hilt is fully integrated (prerequisite #9 ✅ Done).** The CompositionLocal bridging
+> pattern described here is no longer needed for `AppSettingsDataStore` or any repository.
+> All dependencies must be provided through `@HiltViewModel` constructor injection.
+>
+> Do **not** create `staticCompositionLocalOf<AppSettingsDataStore>` or similar —
+> use `@Inject constructor(private val appSettings: AppSettingsDataStore)` in the ViewModel.
 
-```kotlin
-val LocalSessionManager = staticCompositionLocalOf<SessionManager> {
-    error("SessionManager not provided")
-}
-
-// In the Activity bridge host:
-binding.composeContainer.setContent {
-    CompositionLocalProvider(LocalSessionManager provides sessionManager) {
-        AkilimoTheme { SomeScreen() }
-    }
-}
-```
-
-Remove all CompositionLocal bridges once Hilt is active.
+If a rare third-party View-only dependency has no Hilt binding, the `CompositionLocal`
+technique remains available as a last resort for that specific case only. Remove it
+once a proper Hilt module is in place.
 
 ---
 
@@ -602,14 +599,14 @@ Complete before writing any `@Composable` production code.
 
 | Task | Owner note |
 |------|------------|
-| Remove `allowMainThreadQueries()` | AppDatabase.kt |
-| Move API keys to BuildConfig | build.gradle.kts + local.properties |
-| Enable R8 minification | build.gradle.kts release config |
-| Add ViewModels to all existing activities/fragments | one ViewModel per screen |
-| Proper Room migrations | AppDatabase.kt Migration objects |
-| Integrate Hilt | @HiltAndroidApp, @AndroidEntryPoint, @HiltViewModel everywhere |
-| DataStore for language + dark mode | replace SessionManager SharedPrefs |
-| Jetpack NavGraph (View-based first) | replace startActivity() calls |
+| ✅ Remove `allowMainThreadQueries()` | AppDatabase.kt — done |
+| ✅ Move API keys to BuildConfig | build.gradle.kts + local.properties — done |
+| ⬜ Enable R8 minification | build.gradle.kts release config |
+| 🔄 Add ViewModels to all activities/fragments | WelcomeViewModel + UserSettingsViewModel done; all others remain |
+| ⬜ Proper Room migrations | AppDatabase.kt Migration objects |
+| ✅ Integrate Hilt | @HiltAndroidApp on AkilimoApp; @AndroidEntryPoint on 25+ Activities/Fragments; @HiltViewModel on ViewModels; version 2.57.1, kapt — done |
+| ✅ DataStore for ALL 17 settings keys | AppSettingsDataStore replaces deleted SessionManager.kt; SharedPreferencesMigration from "new-akilimo-config" — done |
+| ⬜ Jetpack NavGraph (View-based first) | replace startActivity() calls |
 
 ---
 
@@ -727,8 +724,8 @@ fun OnboardingFlow(onComplete: () -> Unit) {
 | `PlantingDateFragment` | `PlantingDateStepContent` | `OnboardingViewModel.loadDates()` |
 | `TillageOperationFragment` | `TillageStepContent` | `OnboardingViewModel.loadTillage()` |
 | `InvestmentPrefFragment` | `InvestmentPrefStepContent` | `OnboardingViewModel.loadInvestmentPref()` |
-| `DisclaimerFragment` | `DisclaimerStepContent` | shown once; gated by `sessionManager.disclaimerRead` |
-| `TermsFragment` | `TermsStepContent` | shown once; gated by `sessionManager.termsAccepted` |
+| `DisclaimerFragment` | `DisclaimerStepContent` | shown once; gated by `appSettings.disclaimerRead` |
+| `TermsFragment` | `TermsStepContent` | shown once; gated by `appSettings.termsAccepted` |
 | `SummaryFragment` | `SummaryStepContent` | `OnboardingViewModel.buildSummary()` |
 
 ---
@@ -759,7 +756,7 @@ fun AppNavGraph(navController: NavHostController = rememberNavController()) {
 - [ ] Delete all `app/src/main/res/layout/*.xml` files
 - [ ] Delete `base/BaseFragment.kt`, `base/BaseStepFragment.kt`
 - [ ] Remove `StepperLayout`, `ViewPump`, `Reword`, `AppLocale` (replace with Compose locale + DataStore)
-- [ ] Remove `ProcessPhoenix` (no longer needed — Compose recomposes on locale change via `CompositionLocal`)
+- [x] ~~Remove `ProcessPhoenix`~~ — already removed; locale changes use `AppCompatDelegate.setApplicationLocales()`
 - [ ] Remove `CountryCodePicker` view library — replace with Compose version
 - [ ] Keep `BaseActivity` only as a thin Hilt host (`@AndroidEntryPoint` + edge-to-edge setup)
 
@@ -848,8 +845,15 @@ fun CassavaYieldCard(item: CassavaYield, onSelect: (Int) -> Unit) {
 
 ## 10. Stepper Replacement Strategy
 
-The existing `StepperLayout` library (com.stepstone.stepper) drives `HomeStepperActivity`.
-It has no Compose port and must be fully replaced.
+> **Partial migration already done.** `HomeStepperActivity` has been migrated from the
+> `StepperLayout` library (com.stepstone.stepper) to **ViewPager2 + a custom `WizardAdapter`**
+> with a `WizardStep` interface, `BaseStepFragment`, and a `pendingOnSelected` pattern.
+> Phase 4 now replaces the ViewPager2-based wizard with a `HorizontalPager` Compose
+> implementation. The `com.stepstone.stepper` dependency may still be present in
+> `app/build.gradle.kts` but it is no longer driving the UI.
+
+The existing `WizardAdapter` (ViewPager2) drives `HomeStepperActivity` after the View-layer
+migration. It has no Compose equivalent and must be fully replaced in Phase 4.
 
 ### Replacing `verifyStep()` validation
 
@@ -878,8 +882,8 @@ In Compose, drive this through ViewModel state:
 
 ```kotlin
 val steps: StateFlow<List<OnboardingStep>> = combine(
-    sessionManager.disclaimerRead,
-    sessionManager.termsAccepted,
+    appSettings.disclaimerRead,   // AppSettingsDataStore Flow<Boolean>
+    appSettings.termsAccepted,    // AppSettingsDataStore Flow<Boolean>
 ) { disclaimerRead, termsAccepted ->
     buildList {
         add(OnboardingStep.Welcome)
@@ -916,15 +920,15 @@ val steps: StateFlow<List<OnboardingStep>> = combine(
 
 These dependencies become redundant after full migration and must be removed in Phase 5:
 
-| Library | Replacement |
-|---------|-------------|
-| `com.stepstone.stepper` | Custom `HorizontalPager` `OnboardingFlow` |
-| `dev.b3nedikt.app_locale` + `reword` + `viewpump` | Compose `CompositionLocalProvider(LocalContext)` + `AppCompatDelegate` |
-| `com.jakewharton.processphoenix` | Compose recomposition on locale `CompositionLocal` change |
-| `io.github.chaosleung:pinview` (if present) | Compose `BasicTextField` |
-| `hbb20:ccp` (Country Code Picker) | Compose `ExposedDropdownMenuBox` |
-| `androidx.viewbinding` (buildFeature) | All ViewBinding generated classes removed |
-| `io.github.chuckerteam:chucker` (if debug) | OkHttp logging interceptor |
+| Library | Replacement | Status |
+|---------|-------------|--------|
+| `com.stepstone.stepper` | Custom `HorizontalPager` `OnboardingFlow` | ⬜ Still needed (ViewPager2 wizard is interim; replace in Phase 4) |
+| `dev.b3nedikt.app_locale` + `reword` + `viewpump` | Compose `CompositionLocalProvider(LocalContext)` + `AppCompatDelegate` | ⬜ Remove in Phase 5 |
+| `com.jakewharton.processphoenix` | `AppCompatDelegate.setApplicationLocales()` — in-process locale change | ✅ Already removed from `app/build.gradle.kts` |
+| `io.github.chaosleung:pinview` (if present) | Compose `BasicTextField` | ⬜ Remove in Phase 5 |
+| `hbb20:ccp` (Country Code Picker) | Compose `ExposedDropdownMenuBox` | ⬜ Remove in Phase 5 |
+| `androidx.viewbinding` (buildFeature) | All ViewBinding generated classes removed | ⬜ Remove in Phase 5 final cleanup |
+| `io.github.chuckerteam:chucker` (if debug) | OkHttp logging interceptor | ⬜ Remove in Phase 5 |
 
 **Do not** remove `retrofit`, `okhttp`, `room`, `hilt`, `moshi`, `firebase`, `mapbox`, `timber`,
 `sentry`, or `workmanager` — all survive the Compose migration.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,7 +55,9 @@ Main package: `com.akilimo.mobile`
 | `dao/` + `entities/` | Room `@Dao` interfaces and `@Entity` data classes |
 | `workers/` | WorkManager `CoroutineWorker` subclasses + `WorkerScheduler` |
 | `network/` + `rest/` | Retrofit service interfaces, `ApiClient`, request/response models |
-| `helper/` | `SessionManager` (SharedPrefs singleton), `LocaleHelper` (locale context wrapper) |
+| `data/` | `AppSettingsDataStore.kt` — Preferences DataStore for all 17 settings keys (replaces deleted `SessionManager`) |
+| `helper/` | `LocaleHelper` (locale context wrapper); `SessionManager` has been deleted |
+| `ui/viewmodels/` | `WelcomeViewModel`, `UserSettingsViewModel` (key screens); expand as more screens are migrated |
 | `enums/` | Domain enums: `EnumCountry`, `EnumAreaUnit`, `EnumAdvice`, etc. |
 
 **When adding a new screen (current View system):**
@@ -63,9 +65,9 @@ Main package: `com.akilimo.mobile`
 2. Create a typed Repo class in `repos/` backed by a DAO.
 3. Launch via explicit `Intent` (NavGraph not yet active).
 
-> **⚠️ Compose migration in progress.** Once Hilt and NavGraph are active (ROADMAP #9, #12),
-> all new screens must be written as `@Composable` functions with a `@HiltViewModel`.
-> Do not add new activities after Phase 1 of the migration begins.
+> **⚠️ Compose migration in progress.** Hilt is now active (ROADMAP #9 ✅ Done).
+> Once NavGraph is active (ROADMAP #12), all new screens must be written as `@Composable`
+> functions with a `@HiltViewModel`. Do not add new activities after Phase 1 of the migration begins.
 > See `docs/COMPOSE_MIGRATION.md` for conventions.
 
 **When adding a new stepper step:**
@@ -77,7 +79,15 @@ Main package: `com.akilimo.mobile`
 **Language/locale changes:**
 - Always save language as a full BCP-47 tag (e.g., `"sw-TZ"`, not `"sw"`).
 - Use `Locales.supportedLocales` as the single source of supported locales.
-- After saving, set `AppLocale.desiredLocale` and call `ProcessPhoenix.triggerRebirth()`.
+- Write to DataStore **before** calling `setApplicationLocales()` to prevent a stale locale read during activity recreation (race condition fix):
+  ```kotlin
+  safeScope.launch {
+      appSettings.setLanguageTag(tag)
+      AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(tag))
+      AppLocale.desiredLocale = …   // secondary step for Reword string-replacement library
+  }
+  ```
+- `ProcessPhoenix` has been removed — `AppCompatDelegate.setApplicationLocales()` recreates activities in-process.
 - See `docs/ARCHITECTURE.md §5` for the full locale system.
 
 ## 5. Database and threading
@@ -166,15 +176,18 @@ private fun UserSettingsScreenPreview() {
 - ❌ Do not use `findViewById` in migrated screens.
 - ❌ Do not mix ViewBinding and Compose in the same screen after migration.
 - ❌ Do not call `startActivity()` from a Compose screen — use `navController.navigate()`.
-- ❌ Do not access `SessionManager` directly from a composable — inject via ViewModel.
+- ❌ Do not access `AppSettingsDataStore` directly from a composable — inject via `@HiltViewModel`.
 
 ## 10. Known active bugs
 
 | Ticket | Status | Description | Files |
 |--------|--------|-------------|-------|
-| MUN-16 | ✅ Fixed | Language selection did not persist — short codes, missing AppLocale sync, wrong restart method | `WelcomeFragment.kt`, `UserSettingsActivity.kt`, `AkilimoApp.kt`, `SessionManager.kt` |
+| MUN-16 | ✅ Fixed | Language selection did not persist — short codes, missing AppLocale sync, race condition on activity recreation | `WelcomeFragment.kt`, `UserSettingsActivity.kt`, `AkilimoApp.kt`, `AppSettingsDataStore.kt` |
+| MUN-22 | ✅ Fixed | Hilt `@AndroidEntryPoint` missing on concrete Activities/Fragments — covered all 25+ entry points | All activity/fragment files |
+| feat/#475 | ✅ Fixed | DataStore migration — `SessionManager.kt` deleted; `AppSettingsDataStore` covers all 17 settings keys with `SharedPreferencesMigration` | `data/AppSettingsDataStore.kt`, `BaseActivity.kt`, `BaseFragment.kt` |
+| — | ✅ Fixed | Language race condition — DataStore write now happens inside `safeScope.launch` before `setApplicationLocales()` call | `WelcomeFragment.kt` |
 | — | ✅ Fixed | WorkManager `IllegalStateException` on app start — missing `Configuration.Provider` | `AkilimoApp.kt`, `AndroidManifest.xml` |
-| — | ✅ Fixed | Dark mode setting saved but never applied — `MODE_NIGHT_NO` override removed; now driven by `SessionManager.darkMode` in `AkilimoApp` | `BaseActivity.kt`, `AkilimoApp.kt`, `SessionManager.kt` |
+| — | ✅ Fixed | Dark mode setting saved but never applied — `MODE_NIGHT_NO` override removed; now driven by `AppSettingsDataStore.darkMode` in `AkilimoApp` | `BaseActivity.kt`, `AkilimoApp.kt` |
 | — | ✅ Fixed | `allowMainThreadQueries()` removed — all DB calls confirmed in coroutines | `AppDatabase.kt` |
 
 See `docs/ARCHITECTURE.md §10` for the full technical debt register and `docs/ROADMAP.md` for prioritised fix order.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,7 @@ These are fixes to active bugs and security issues. All are self-contained with 
 
 | # | Status | Task | Files | Effort | Impact |
 |---|--------|------|-------|--------|--------|
-| 1 | ✅ Done | **Fix MUN-16: Language persistence** — full BCP-47 tags, AppLocale sync, ProcessPhoenix in WelcomeFragment, save to UserPreferences | `WelcomeFragment.kt`, `UserSettingsActivity.kt`, `AkilimoApp.kt`, `SessionManager.kt` | S | Critical |
+| 1 | ✅ Done | **Fix MUN-16: Language persistence** — full BCP-47 tags, DataStore write before `setApplicationLocales()` (race fix), `AppCompatDelegate` in-process locale change replaces ProcessPhoenix | `WelcomeFragment.kt`, `UserSettingsActivity.kt`, `AkilimoApp.kt`, `AppSettingsDataStore.kt` | S | Critical |
 | 1a | ✅ Done | **Fix WorkManager initialization** — implement `Configuration.Provider` in `AkilimoApp`; remove `WorkManagerInitializer` from startup | `AkilimoApp.kt`, `AndroidManifest.xml` | S | Critical |
 | 2 | ✅ Done | **Fix dark mode** — removed `MODE_NIGHT_NO` override; `AkilimoApp` applies night mode from `SessionManager.darkMode`; fixed StepperLayout bottom bar, welcome card, terms WebView background, and three hardcoded-black icon tints | `BaseActivity.kt`, `AkilimoApp.kt`, `SessionManager.kt`, `UserSettingsActivity.kt`, `activity_home_stepper.xml`, `fragment_welcome.xml`, `fragment_terms.xml`, `ic_*.xml` | S | High |
 | 2a | ✅ Done | **Consistent image-tap selection UX** — animated card highlight, 2dp primary stroke border, selectionOverlay + selectionIndicator on tap; fixed `SelectedCassavaMarketRepo.select()` not persisting `yieldId`; fixed `DiffCallback.areItemsTheSame` in both adapters; aligned `MaizePerformanceAdapter` to same pattern | `CassavaYieldAdapter.kt`, `MaizePerformanceAdapter.kt`, `SelectedCassavaMarketRepo.kt`, `item_card_recommendation_image.xml` | S | UX |
@@ -28,12 +28,12 @@ See `docs/COMPOSE_MIGRATION.md §2` for why each one is required.
 
 | # | Task | Files | Effort | Impact | Compose dependency |
 |---|------|-------|--------|--------|-------------------|
-| 7 | **Introduce ViewModels** — one per screen; expose `StateFlow<UiState>`; move all DB/SharedPrefs calls out of Activity/Fragment | `ui/activities/`, `ui/fragments/` | M | Architecture | Required — `collectAsStateWithLifecycle()` needs a ViewModel |
-| 8 | **Proper Room migrations** — replace `fallbackToDestructiveMigration()` with `Migration` objects | `AppDatabase.kt` | M | Data integrity | Required — schema changes during migration must not wipe data |
-| 9 | **Introduce Hilt** — `@HiltAndroidApp` on `AkilimoApp`; `@AndroidEntryPoint` on all activities; `@HiltViewModel` on all ViewModels; inject repos via constructor | All | L | Maintainability | Required — `hiltViewModel()` in composables |
-| 10 | **Consolidate language + dark mode to DataStore** — single reactive source replaces dual SharedPrefs; expose as `Flow<String>` and `Flow<Boolean>` | `SessionManager.kt`, `AkilimoApp.kt`, `BaseActivity.kt` | M | Reliability | Required — Compose observes `DataStore` via `collectAsState()` |
-| 11 | **Unit test coverage for repos and locale logic** — `UserPreferencesRepo`, `LocaleHelper`, `SessionManager`, all ViewModels | `test/` | M | Quality | Required — ViewModel unit tests validate `UiState` transitions |
-| 12 | **Jetpack NavGraph (View-based first)** — replace all `startActivity()` / `Intent` navigation with typed `NavGraph` destinations; enables `navigation-compose` in Phase 5 | All activities | L | Architecture | Required — `NavHost` is the Compose navigation backbone |
+| 7 | 🔄 Partial | **Introduce ViewModels** — one per screen; expose `StateFlow<UiState>`; move all DB/DataStore calls out of Activity/Fragment. `WelcomeViewModel` and `UserSettingsViewModel` done; remaining screens still load directly from repos | `ui/activities/`, `ui/fragments/`, `ui/viewmodels/` | M | Architecture | Required — `collectAsStateWithLifecycle()` needs a ViewModel |
+| 8 | ⬜ | **Proper Room migrations** — replace `fallbackToDestructiveMigration()` with `Migration` objects | `AppDatabase.kt` | M | Data integrity | Required — schema changes during migration must not wipe data |
+| 9 | ✅ Done | **Introduce Hilt** — `@HiltAndroidApp` on `AkilimoApp`; `@AndroidEntryPoint` on all 25+ concrete Activities/Fragments; `@HiltViewModel` on ViewModels; inject repos via constructor. Version: `hilt = "2.57.1"`, uses `kapt` | All | L | Maintainability | Required — `hiltViewModel()` in composables |
+| 10 | ✅ Done | **Consolidate ALL settings to DataStore** — `AppSettingsDataStore` covers all 17 keys (language, darkMode, akilimoUser, termsAccepted, disclaimerRead, rememberAreaUnit, isFertilizerGrid, deviceToken, apiToken, apiRefreshToken, mapBoxApiKey, locationIqToken, isFirstRun, notificationCount, termsLink, akilimoEndpoint, fuelrodEndpoint); `SessionManager.kt` deleted; `SharedPreferencesMigration` from `"new-akilimo-config"` | `data/AppSettingsDataStore.kt`, `AkilimoApp.kt`, `BaseActivity.kt`, `BaseFragment.kt` | M | Reliability | Required — Compose observes `DataStore` via `collectAsState()` |
+| 11 | ⬜ | **Unit test coverage for repos and locale logic** — `UserPreferencesRepo`, `LocaleHelper`, `AppSettingsDataStore`, all ViewModels | `test/` | M | Quality | Required — ViewModel unit tests validate `UiState` transitions |
+| 12 | ⬜ | **Jetpack NavGraph (View-based first)** — replace all `startActivity()` / `Intent` navigation with typed `NavGraph` destinations; enables `navigation-compose` in Phase 5 | All activities | L | Architecture | Required — `NavHost` is the Compose navigation backbone |
 
 ---
 
@@ -59,12 +59,14 @@ Full migration to Jetpack Compose. Executed in five phases as detailed in
 ## Milestone Summary
 
 ```
-Week 1-4:    Bug fixes + security hardening (items 1–5)         ← mostly done ✅
-Month 2:     ViewModels + Room migrations + Hilt (items 7–9)
-Month 3:     DataStore + NavGraph + unit tests (items 10–12)
+Week 1-4:    Bug fixes + security hardening (items 1–5)         ← done ✅
+Month 2–3:   Hilt (#9) ✅ + DataStore (#10) ✅ — completed ahead of schedule
+             ViewModels (#7) 🔄 Partial — key screens done; all screens remaining
+             Room migrations (#8) + NavGraph (#12) + unit tests (#11) — still open
 Month 4:     Compose infrastructure + leaf screens (items 13–14)
 Month 5–6:   Domain screens migration (item 15)
 Month 7–8:   Stepper replacement + onboarding flow (item 16)
+             Note: HomeStepperActivity already migrated from StepperLayout → ViewPager2 + WizardAdapter
 Month 9–10:  NavGraph consolidation + library cleanup (item 17)
 Month 11–12: Deep links + offline cache + accessibility (items 18–21)
 ```


### PR DESCRIPTION
- **✨ chore: migrate session management to Hilt and DataStore**
  Implement Hilt DI and replace SharedPreferences with Preferences
  DataStore for all 17 settings keys. Fixes locale race conditions.
  
  - Integrate Hilt 2.57.1 across 25+ Activities and Fragments.
  - Delete `SessionManager.kt` and implement `AppSettingsDataStore.kt`.
  - Replace `ProcessPhoenix` with `AppCompatDelegate` for locale changes.
  - Add `WelcomeViewModel` and `UserSettingsViewModel` as part of MVVM.
  
  Closes #9
  Closes #10
  Closes #16
  Closes #475
  

- **🐛 fix(activity): fix mapbox token initialization**
  Use BuildConfig for the Mapbox token instead of SessionManager during
  attachBaseContext to avoid issues where Hilt is not yet injected.
  

- **🐛 fix(activity): adjust edge-to-edge initialization order**
  Move the enableEdgeToEdge call after super.onCreate to ensure the
  activity is fully initialized before applying system UI configurations.
  

- **♻️ refactor(activity): implement entrypoint for appsettings**
  Replace field injection with Hilt EntryPoint in base classes to avoid
  lateinit initialization risks and simplify dependency access.
  

- **🐛 fix(ui): synchronize cassava market selection state**
  Use Flow combine to reactively update factory and unit lists based on
  user selection. Ensure initial market choice is applied only once.
  