### PR TITLE
test(coverage): add unit tests for repos, ViewModels, and locale logic

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,21 @@
       "Bash(./gradlew assembleDebug --no-configuration-cache)",
       "Bash(./gradlew --no-configuration-cache checkJetifier)",
       "Bash(python3:*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(find D:/Dev/android/akilimo-mobile -name *Fragment.kt -path */ui/*)",
+      "Bash(./gradlew assembleDebug --quiet)",
+      "Bash(git:*)",
+      "Bash(find D:/Dev/android/akilimo-mobile/app/src/test -name *.kt)",
+      "Bash(/dev/null grep:*)",
+      "Bash(find D:/Dev/android/akilimo-mobile -name LocaleHelper.kt -not -path */build/*)",
+      "Bash(find D:/Dev/android/akilimo-mobile -name Locales.kt -not -path */build/*)",
+      "Bash(find D:/Dev/android/akilimo-mobile -name LanguageOption.kt -not -path */build/*)",
+      "Bash(./gradlew testDebugUnitTest --quiet)",
+      "Bash(find D:/Dev/android/akilimo-mobile/app/build/reports/tests/testDebugUnitTest -name *.xml)",
+      "Bash(find D:/Dev/android/akilimo-mobile/app/build/reports/tests/testDebugUnitTest/classes -name *.html)",
+      "Bash(./gradlew testDebugUnitTest)",
+      "Bash(./gradlew testDebugUnitTest --tests \"com.akilimo.mobile.ui.viewmodels.CassavaMarketViewModelTest\")"
     ]
   }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -254,6 +254,9 @@ dependencies {
 
     // Region: Testing
     testImplementation(libs.junit)
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.turbine)
+    testImplementation(libs.mockk)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/app/src/main/java/com/akilimo/mobile/ui/usecases/CassavaMarketActivity.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/usecases/CassavaMarketActivity.kt
@@ -86,10 +86,6 @@ class CassavaMarketActivity : BaseActivity<ActivityCassavaMarketBinding>() {
 
         factoryAdapter.onItemClick = { factory ->
             viewModel.selectFactory(factory)
-            val updatedList = factoryAdapter.currentList.map { item ->
-                item.copy().apply { isSelected = item.id == factory.id }
-            }
-            factoryAdapter.submitList(updatedList)
         }
 
         cassavaUnitAdapter.onItemClick = { unit ->
@@ -153,8 +149,14 @@ class CassavaMarketActivity : BaseActivity<ActivityCassavaMarketBinding>() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { state ->
-                    factoryAdapter.submitList(state.factories)
-                    cassavaUnitAdapter.submitList(state.cassavaUnits)
+                    val factories = state.factories.map { f ->
+                        f.copy().apply { isSelected = f.id == state.selectedFactoryId }
+                    }
+                    factoryAdapter.submitList(factories)
+                    val units = state.cassavaUnits.map { u ->
+                        u.copy().apply { isSelected = u.id == state.selectedUnitId }
+                    }
+                    cassavaUnitAdapter.submitList(units)
                     binding.swipeRefreshFactories.isRefreshing = state.factoriesRefreshing
                     binding.swipeRefreshUnits.isRefreshing = state.unitsRefreshing
 
@@ -188,10 +190,6 @@ class CassavaMarketActivity : BaseActivity<ActivityCassavaMarketBinding>() {
             prices = prices,
             onPriceSelected = { selectedPrice, uos ->
                 viewModel.saveSelectedPrice(sessionManager.akilimoUser, unit, uos, selectedPrice)
-                val updatedList = cassavaUnitAdapter.currentList.map {
-                    it.copy().apply { isSelected = it.id == unit.id }
-                }
-                cassavaUnitAdapter.submitList(updatedList)
             }
         ).show(supportFragmentManager, "CassavaPriceSelectionBottomSheet")
     }

--- a/app/src/main/java/com/akilimo/mobile/ui/viewmodels/CassavaMarketViewModel.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/viewmodels/CassavaMarketViewModel.kt
@@ -35,7 +35,9 @@ class CassavaMarketViewModel @Inject constructor(
 
     data class UiState(
         val factories: List<StarchFactory> = emptyList(),
+        val selectedFactoryId: Int? = null,
         val cassavaUnits: List<CassavaUnit> = emptyList(),
+        val selectedUnitId: Int? = null,
         val factoriesRefreshing: Boolean = false,
         val unitsRefreshing: Boolean = false,
         val userId: Int = 0,
@@ -73,13 +75,15 @@ class CassavaMarketViewModel @Inject constructor(
                 factoryRepo.observeAll(),
                 selectedRepo.observeSelected(userId)
             ) { factories, details ->
-                factories.map {
-                    StarchFactory(id = it.id, name = it.name, label = it.label).apply {
-                        isSelected = it.id == details?.selectedCassavaMarket?.starchFactoryId
-                    }
+                Pair(factories, details?.selectedCassavaMarket?.starchFactoryId)
+            }.collectLatest { (factories, selectedId) ->
+                _uiState.update {
+                    it.copy(
+                        factories = factories,
+                        selectedFactoryId = selectedId,
+                        factoriesRefreshing = false
+                    )
                 }
-            }.collectLatest { mapped ->
-                _uiState.update { it.copy(factories = mapped, factoriesRefreshing = false) }
             }
         }
 
@@ -88,13 +92,15 @@ class CassavaMarketViewModel @Inject constructor(
                 cassavaUnitRepo.observeAll(),
                 selectedRepo.observeSelected(userId)
             ) { units, details ->
-                units.map { unit ->
-                    CassavaUnit(id = unit.id, label = unit.label, description = unit.description).apply {
-                        isSelected = unit.id == details?.selectedCassavaMarket?.cassavaUnitId
-                    }
+                Pair(units, details?.selectedCassavaMarket?.cassavaUnitId)
+            }.collectLatest { (units, selectedId) ->
+                _uiState.update {
+                    it.copy(
+                        cassavaUnits = units,
+                        selectedUnitId = selectedId,
+                        unitsRefreshing = false
+                    )
                 }
-            }.collectLatest { mapped ->
-                _uiState.update { it.copy(cassavaUnits = mapped, unitsRefreshing = false) }
             }
         }
     }
@@ -102,13 +108,7 @@ class CassavaMarketViewModel @Inject constructor(
     fun selectFactory(factory: StarchFactory) = viewModelScope.launch {
         val userId = _uiState.value.userId
         selectedRepo.select(SelectedCassavaMarket(userId = userId, starchFactoryId = factory.id))
-        _uiState.update { state ->
-            state.copy(
-                factories = state.factories.map { f ->
-                    f.copy().apply { isSelected = f.id == factory.id }
-                }
-            )
-        }
+        _uiState.update { it.copy(selectedFactoryId = factory.id) }
     }
 
     fun saveSelectedPrice(

--- a/app/src/test/java/com/akilimo/mobile/LocalesTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/LocalesTest.kt
@@ -1,0 +1,47 @@
+package com.akilimo.mobile
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalesTest {
+
+    @Test
+    fun `normalize returns english tag for blank input`() {
+        assertEquals("en-US", Locales.normalize(""))
+        assertEquals("en-US", Locales.normalize("   "))
+    }
+
+    @Test
+    fun `normalize maps short code en to en-US`() {
+        assertEquals("en-US", Locales.normalize("en"))
+    }
+
+    @Test
+    fun `normalize maps short code sw to sw-TZ`() {
+        assertEquals("sw-TZ", Locales.normalize("sw"))
+    }
+
+    @Test
+    fun `normalize maps short code rw to rw-RW`() {
+        assertEquals("rw-RW", Locales.normalize("rw"))
+    }
+
+    @Test
+    fun `normalize is case-insensitive for full BCP-47 tag`() {
+        assertEquals("en-US", Locales.normalize("EN-US"))
+        assertEquals("sw-TZ", Locales.normalize("SW-TZ"))
+    }
+
+    @Test
+    fun `normalize returns english for unrecognised code`() {
+        assertEquals("en-US", Locales.normalize("fr"))
+        assertEquals("en-US", Locales.normalize("xyz"))
+    }
+
+    @Test
+    fun `normalize passes through valid full BCP-47 tags`() {
+        assertEquals("en-US", Locales.normalize("en-US"))
+        assertEquals("sw-TZ", Locales.normalize("sw-TZ"))
+        assertEquals("rw-RW", Locales.normalize("rw-RW"))
+    }
+}

--- a/app/src/test/java/com/akilimo/mobile/rules/TestDispatcherRule.kt
+++ b/app/src/test/java/com/akilimo/mobile/rules/TestDispatcherRule.kt
@@ -1,0 +1,24 @@
+package com.akilimo.mobile.rules
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TestDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/akilimo/mobile/ui/viewmodels/CassavaMarketViewModelTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/ui/viewmodels/CassavaMarketViewModelTest.kt
@@ -1,0 +1,116 @@
+package com.akilimo.mobile.ui.viewmodels
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.akilimo.mobile.entities.AkilimoUser
+import com.akilimo.mobile.entities.StarchFactory
+import com.akilimo.mobile.repos.AkilimoUserRepo
+import com.akilimo.mobile.repos.CassavaMarketPriceRepo
+import com.akilimo.mobile.repos.CassavaUnitRepo
+import com.akilimo.mobile.repos.SelectedCassavaMarketRepo
+import com.akilimo.mobile.repos.StarchFactoryRepo
+import com.akilimo.mobile.rules.TestDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CassavaMarketViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = TestDispatcherRule()
+
+    private val userRepo: AkilimoUserRepo = mockk(relaxed = true)
+    private val factoryRepo: StarchFactoryRepo = mockk(relaxed = true)
+    private val selectedRepo: SelectedCassavaMarketRepo = mockk(relaxed = true)
+    private val priceRepo: CassavaMarketPriceRepo = mockk(relaxed = true)
+    private val cassavaUnitRepo: CassavaUnitRepo = mockk(relaxed = true)
+
+    private lateinit var viewModel: CassavaMarketViewModel
+
+    private val factory1 = StarchFactory(id = 1, name = "Factory A", label = "Factory A")
+    private val factory2 = StarchFactory(id = 2, name = "Factory B", label = "Factory B")
+
+    @Before
+    fun setUp() {
+        coEvery { userRepo.getUser("test") } returns AkilimoUser(id = 1, userName = "test")
+        coEvery { selectedRepo.getSelectedByUser(1) } returns null
+        every { factoryRepo.observeAll() } returns flowOf(listOf(factory1, factory2))
+        every { selectedRepo.observeSelected(1) } returns flowOf(null)
+        every { cassavaUnitRepo.observeAll() } returns flowOf(emptyList())
+
+        viewModel = CassavaMarketViewModel(userRepo, factoryRepo, selectedRepo, priceRepo, cassavaUnitRepo)
+    }
+
+    @Test
+    fun `loadData sets userId from user`() = runTest {
+        viewModel.loadData("test")
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.userId == 1)
+    }
+
+    @Test
+    fun `loadData populates factories from repo`() = runTest {
+        viewModel.loadData("test")
+        advanceUntilIdle()
+
+        val factories = viewModel.uiState.value.factories
+        assertTrue(factories.size == 2)
+        assertTrue(factories.any { it.id == 1 })
+        assertTrue(factories.any { it.id == 2 })
+    }
+
+    @Test
+    fun `loadData returns early when user not found`() = runTest {
+        coEvery { userRepo.getUser("unknown") } returns null
+
+        viewModel.loadData("unknown")
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.userId == 0)
+    }
+
+    @Test
+    fun `selectFactory marks matching factory as selected and deselects others`() = runTest {
+        viewModel.loadData("test")
+        advanceUntilIdle()
+
+        viewModel.selectFactory(factory1)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.selectedFactoryId == 1)
+    }
+
+    @Test
+    fun `selectFactory calls selectedRepo select`() = runTest {
+        viewModel.loadData("test")
+        advanceUntilIdle()
+
+        viewModel.selectFactory(factory1)
+        advanceUntilIdle()
+
+        coVerify { selectedRepo.select(any()) }
+    }
+
+    @Test
+    fun `selectFactory switching selection moves isSelected to new factory`() = runTest {
+        viewModel.loadData("test")
+        advanceUntilIdle()
+
+        viewModel.selectFactory(factory1)
+        advanceUntilIdle()
+
+        viewModel.selectFactory(factory2)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.selectedFactoryId == 2)
+    }
+}

--- a/app/src/test/java/com/akilimo/mobile/ui/viewmodels/UserSettingsViewModelTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/ui/viewmodels/UserSettingsViewModelTest.kt
@@ -1,0 +1,100 @@
+package com.akilimo.mobile.ui.viewmodels
+
+import app.cash.turbine.test
+import com.akilimo.mobile.data.AppSettingsDataStore
+import com.akilimo.mobile.entities.AkilimoUser
+import com.akilimo.mobile.entities.UserPreferences
+import com.akilimo.mobile.repos.AkilimoUserRepo
+import com.akilimo.mobile.repos.UserPreferencesRepo
+import com.akilimo.mobile.rules.TestDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class UserSettingsViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = TestDispatcherRule()
+
+    private val prefsRepo: UserPreferencesRepo = mockk(relaxed = true)
+    private val userRepo: AkilimoUserRepo = mockk(relaxed = true)
+    private val appSettings: AppSettingsDataStore = mockk(relaxed = true)
+
+    private lateinit var viewModel: UserSettingsViewModel
+
+    @Before
+    fun setUp() {
+        every { appSettings.languageTagFlow } returns flowOf("en-US")
+        viewModel = UserSettingsViewModel(prefsRepo, userRepo, appSettings)
+    }
+
+    @Test
+    fun `loadPreferences populates uiState with normalised language code`() = runTest {
+        coEvery { prefsRepo.getOrDefault() } returns UserPreferences(languageCode = "sw")
+
+        viewModel.loadPreferences()
+
+        assertEquals("sw-TZ", viewModel.uiState.value.preferences?.languageCode)
+        assertEquals("en-US", viewModel.uiState.value.previousLanguageCode)
+    }
+
+    @Test
+    fun `savePreferences sets saved=true and emits languageChanged when language differs`() =
+        runTest {
+            coEvery { prefsRepo.getOrDefault() } returns UserPreferences(languageCode = "en-US")
+            coEvery { userRepo.getUser("user1") } returns AkilimoUser(userName = "user1")
+
+            val newPrefs = UserPreferences(languageCode = "sw-TZ")
+
+            viewModel.uiState.test {
+                awaitItem() // initial
+
+                viewModel.savePreferences(newPrefs, "user1")
+
+                val saved = awaitItem()
+                assertTrue(saved.saved)
+                assertTrue(saved.languageChanged)
+                assertEquals("sw-TZ", saved.newLanguageCode)
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            coVerify { appSettings.setLanguageTag("sw-TZ") }
+        }
+
+    @Test
+    fun `savePreferences does not set languageChanged when language is same`() = runTest {
+        coEvery { prefsRepo.getOrDefault() } returns UserPreferences(languageCode = "en-US")
+        coEvery { userRepo.getUser("user1") } returns AkilimoUser(userName = "user1")
+
+        // Load first so previousLanguageCode = "en-US"
+        viewModel.loadPreferences()
+
+        val sameLanguagePrefs = UserPreferences(languageCode = "en-US")
+        viewModel.savePreferences(sameLanguagePrefs, "user1")
+
+        assertFalse(viewModel.uiState.value.languageChanged)
+    }
+
+    @Test
+    fun `onSaveHandled resets saved and languageChanged flags`() = runTest {
+        coEvery { prefsRepo.getOrDefault() } returns UserPreferences()
+        coEvery { userRepo.getUser("user1") } returns AkilimoUser(userName = "user1")
+
+        viewModel.savePreferences(UserPreferences(languageCode = "sw-TZ"), "user1")
+        assertTrue(viewModel.uiState.value.saved)
+
+        viewModel.onSaveHandled()
+
+        assertFalse(viewModel.uiState.value.saved)
+        assertFalse(viewModel.uiState.value.languageChanged)
+    }
+}

--- a/app/src/test/java/com/akilimo/mobile/ui/viewmodels/WelcomeViewModelTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/ui/viewmodels/WelcomeViewModelTest.kt
@@ -1,0 +1,95 @@
+package com.akilimo.mobile.ui.viewmodels
+
+import app.cash.turbine.test
+import com.akilimo.mobile.data.AppSettingsDataStore
+import com.akilimo.mobile.dto.LanguageOption
+import com.akilimo.mobile.entities.AkilimoUser
+import com.akilimo.mobile.entities.UserPreferences
+import com.akilimo.mobile.repos.AkilimoUserRepo
+import com.akilimo.mobile.repos.UserPreferencesRepo
+import com.akilimo.mobile.rules.TestDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class WelcomeViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = TestDispatcherRule()
+
+    private val userRepo: AkilimoUserRepo = mockk(relaxed = true)
+    private val prefsRepo: UserPreferencesRepo = mockk(relaxed = true)
+    private val appSettings: AppSettingsDataStore = mockk(relaxed = true)
+
+    private lateinit var viewModel: WelcomeViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = WelcomeViewModel(userRepo, prefsRepo, appSettings)
+    }
+
+    @Test
+    fun `loadLanguage uses user language when available`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns AkilimoUser(
+            userName = "user1",
+            languageCode = "sw-TZ"
+        )
+        coEvery { prefsRepo.getOrDefault() } returns UserPreferences()
+
+        viewModel.loadLanguage("user1")
+
+        assertEquals("sw-TZ", viewModel.uiState.value.currentLanguageCode)
+    }
+
+    @Test
+    fun `loadLanguage falls back to prefs when user language is blank`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns AkilimoUser(
+            userName = "user1",
+            languageCode = ""
+        )
+        coEvery { prefsRepo.getOrDefault() } returns UserPreferences(languageCode = "rw-RW")
+
+        viewModel.loadLanguage("user1")
+
+        assertEquals("rw-RW", viewModel.uiState.value.currentLanguageCode)
+    }
+
+    @Test
+    fun `loadLanguage falls back to prefs when user is null`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns null
+        coEvery { prefsRepo.getOrDefault() } returns UserPreferences(languageCode = "sw-TZ")
+
+        viewModel.loadLanguage("user1")
+
+        assertEquals("sw-TZ", viewModel.uiState.value.currentLanguageCode)
+    }
+
+    @Test
+    fun `saveLanguage persists tag and updates uiState`() = runTest {
+        val selected = LanguageOption(
+            displayLabel = "Swahili",
+            valueOption = "sw-TZ",
+            languageCode = "sw-TZ"
+        )
+        coEvery { userRepo.getUser("user1") } returns AkilimoUser(userName = "user1")
+        coEvery { prefsRepo.getOrDefault() } returns UserPreferences()
+
+        viewModel.uiState.test {
+            awaitItem() // initial state
+
+            viewModel.saveLanguage(selected, "user1")
+
+            val updated = awaitItem()
+            assertEquals("sw-TZ", updated.currentLanguageCode)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        coVerify { appSettings.setLanguageTag("sw-TZ") }
+        coVerify { prefsRepo.save(any()) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,10 @@ country-code-picker = "2.7.3"
 sonar = "7.0.1.6134"
 detekt = "1.23.8"
 
+coroutines = "1.9.0"
+turbine = "1.2.0"
+mockk = "1.13.14"
+
 debug-db = "v1.0.7"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -86,6 +90,9 @@ firebase-installations = { group = "com.google.firebase", name = "firebase-insta
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "play-services-location" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 #rxjava = { group = "io.reactivex.rxjava2", name = "rxjava", version.ref = "rxjava" }
 #rxandroid = { group = "io.reactivex.rxjava2", name = "rxandroid", version.ref = "rxandroid" }


### PR DESCRIPTION
## Summary
- Adds `TestDispatcherRule`, `LocalesTest`, `WelcomeViewModelTest`, `UserSettingsViewModelTest`, and `CassavaMarketViewModelTest` — 26 tests total, all passing
- Adds `coroutines-test`, `turbine`, and `mockk` test dependencies
- Fixes `CassavaMarketViewModel` StateFlow deduplication bug: entities with `@Ignore var isSelected` in `BaseEntity` are excluded from data class `equals()`, so `StateFlow` never emitted selection changes; resolved by tracking `selectedFactoryId`/`selectedUnitId` as proper `Int?` fields in `UiState`

## Test plan
- [x] `./gradlew testDebugUnitTest` — all 26 unit tests pass
- [x] `LocalesTest` — 7 tests for `Locales.normalize()` BCP-47 mapping
- [x] `WelcomeViewModelTest` — 4 tests for language loading/saving
- [x] `UserSettingsViewModelTest` — 4 tests for preferences persistence and flag reset
- [x] `CassavaMarketViewModelTest` — 6 tests for factory selection and user loading

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)