### PR TITLE
feat(nav): Option C — convert use-case Activities to NavGraph Fragments

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,7 @@ android {
         versionCode = appVersionCode
         versionName = releaseVersionName
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "com.akilimo.mobile.HiltTestRunner"
 
         val fuelrodBaseUrl =
             env.FUELROD_BASE_URL.orElse("https://akilimo.fuelrod.com")
@@ -259,6 +259,12 @@ dependencies {
     testImplementation(libs.mockk)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.hilt.testing)
+    androidTestImplementation(libs.navigation.testing)
+    androidTestImplementation(libs.mockk.android)
+    androidTestImplementation(libs.room.testing)
+    androidTestImplementation(libs.coroutines.test)
+    kaptAndroidTest(libs.hilt.compiler)
 
     // Region: Debug Tools
     debugImplementation(libs.debug.db)

--- a/app/schemas/com.akilimo.mobile.database.AppDatabase/5.json
+++ b/app/schemas/com.akilimo.mobile.database.AppDatabase/5.json
@@ -1,0 +1,1828 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "58bb8fd579df74a299ed0d9f34ce0f56",
+    "entities": [
+      {
+        "tableName": "fertilizers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER, `key` TEXT, `name` TEXT, `type` TEXT, `weight` REAL NOT NULL, `sort_order` INTEGER NOT NULL, `price` REAL NOT NULL, `use_case` TEXT, `country_code` TEXT, `k_content` INTEGER NOT NULL, `n_content` INTEGER NOT NULL, `p_content` INTEGER NOT NULL, `available` INTEGER NOT NULL, `cim_available` INTEGER NOT NULL, `cis_available` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useCase",
+            "columnName": "use_case",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "country_code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "kContent",
+            "columnName": "k_content",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nContent",
+            "columnName": "n_content",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pContent",
+            "columnName": "p_content",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "available",
+            "columnName": "available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cimAvailable",
+            "columnName": "cim_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cisAvailable",
+            "columnName": "cis_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fertilizers_key_country_code",
+            "unique": true,
+            "columnNames": [
+              "key",
+              "country_code"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_fertilizers_key_country_code` ON `${TABLE_NAME}` (`key`, `country_code`)"
+          }
+        ]
+      },
+      {
+        "tableName": "fertilizer_prices",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `fertilizer_key` TEXT NOT NULL, `fertilizer_country` TEXT NOT NULL, `country_code` TEXT NOT NULL, `currency_code` TEXT NOT NULL, `currency_symbol` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `min_local_price` REAL NOT NULL, `max_local_price` REAL NOT NULL, `min_allowed_price` REAL NOT NULL, `max_allowed_price` REAL NOT NULL, `price_per_bag` REAL NOT NULL, `price_range` TEXT NOT NULL, `active` INTEGER NOT NULL, `description` TEXT, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fertilizerKey",
+            "columnName": "fertilizer_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fertilizerCountry",
+            "columnName": "fertilizer_country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "country_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currency_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencySymbol",
+            "columnName": "currency_symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minLocalPrice",
+            "columnName": "min_local_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxLocalPrice",
+            "columnName": "max_local_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAllowedPrice",
+            "columnName": "min_allowed_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxAllowedPrice",
+            "columnName": "max_allowed_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pricePerBag",
+            "columnName": "price_per_bag",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priceRange",
+            "columnName": "price_range",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "selected_fertilizers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `user_id` INTEGER NOT NULL, `fertilizer_id` INTEGER NOT NULL, `fertilizer_price_id` INTEGER, `fertilizer_price` REAL NOT NULL, `display_price` TEXT, `exact_price` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `akilimo_users`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`fertilizer_id`) REFERENCES `fertilizers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`fertilizer_price_id`) REFERENCES `fertilizer_prices`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fertilizerId",
+            "columnName": "fertilizer_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fertilizerPriceId",
+            "columnName": "fertilizer_price_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fertilizerPrice",
+            "columnName": "fertilizer_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPrice",
+            "columnName": "display_price",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isExactPrice",
+            "columnName": "exact_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_selected_fertilizers_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_selected_fertilizers_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          },
+          {
+            "name": "index_selected_fertilizers_fertilizer_id",
+            "unique": false,
+            "columnNames": [
+              "fertilizer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_selected_fertilizers_fertilizer_id` ON `${TABLE_NAME}` (`fertilizer_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "akilimo_users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "fertilizers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fertilizer_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "fertilizer_prices",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fertilizer_price_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "akilimo_users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `device_token` TEXT, `user_name` TEXT NOT NULL, `first_name` TEXT, `last_name` TEXT, `email` TEXT, `mobile_number` TEXT, `mobile_country_code` TEXT, `farm_name` TEXT, `farm_country` TEXT NOT NULL, `farm_size_unit` TEXT NOT NULL, `farm_size` REAL NOT NULL, `custom_farm_size` INTEGER, `farm_description` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `altitude` REAL NOT NULL, `zoom_level` REAL NOT NULL, `gender` TEXT, `akilimo_interest` TEXT, `send_email` INTEGER NOT NULL, `send_sms` INTEGER NOT NULL, `language_code` TEXT, `risk_att` INTEGER NOT NULL, `planting_date` TEXT, `harvest_date` TEXT, `planting_flex` INTEGER NOT NULL, `harvest_flex` INTEGER NOT NULL, `provided_alternative_date` INTEGER NOT NULL, `tillage_operations` TEXT NOT NULL, `weed_control_method` TEXT, `investment_preferences` TEXT, `active_use_case` TEXT, `last_sync_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deviceToken",
+            "columnName": "device_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "first_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "last_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mobileNumber",
+            "columnName": "mobile_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mobileCountryCode",
+            "columnName": "mobile_country_code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "farmName",
+            "columnName": "farm_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "enumCountry",
+            "columnName": "farm_country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enumAreaUnit",
+            "columnName": "farm_size_unit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "farmSize",
+            "columnName": "farm_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customFarmSize",
+            "columnName": "custom_farm_size",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "farmDescription",
+            "columnName": "farm_description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "altitude",
+            "columnName": "altitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoomLevel",
+            "columnName": "zoom_level",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "akilimoInterest",
+            "columnName": "akilimo_interest",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sendEmail",
+            "columnName": "send_email",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sendSms",
+            "columnName": "send_sms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languageCode",
+            "columnName": "language_code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "riskAtt",
+            "columnName": "risk_att",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plantingDate",
+            "columnName": "planting_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "harvestDate",
+            "columnName": "harvest_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "plantingFlex",
+            "columnName": "planting_flex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "harvestFlex",
+            "columnName": "harvest_flex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providedAlterNativeDate",
+            "columnName": "provided_alternative_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tillageOperations",
+            "columnName": "tillage_operations",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weedControlMethod",
+            "columnName": "weed_control_method",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "investmentPref",
+            "columnName": "investment_preferences",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activeAdvise",
+            "columnName": "active_use_case",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSyncAt",
+            "columnName": "last_sync_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_akilimo_users_user_name",
+            "unique": true,
+            "columnNames": [
+              "user_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_akilimo_users_user_name` ON `${TABLE_NAME}` (`user_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "investment_amounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `country_code` TEXT NOT NULL, `currency_code` TEXT NOT NULL, `currency_symbol` TEXT NOT NULL, `investment_amount` REAL NOT NULL, `exact_amount` INTEGER NOT NULL, `active` INTEGER NOT NULL, `area_unit` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `is_custom` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "country_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currency_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencySymbol",
+            "columnName": "currency_symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "investmentAmount",
+            "columnName": "investment_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactAmount",
+            "columnName": "exact_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "areaUnit",
+            "columnName": "area_unit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "is_custom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "selected_investments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `user_id` INTEGER NOT NULL, `investment_id` INTEGER NOT NULL, `chosen_amount` REAL NOT NULL, `exact_amount` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `akilimo_users`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`investment_id`) REFERENCES `investment_amounts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "investmentId",
+            "columnName": "investment_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chosenAmount",
+            "columnName": "chosen_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isExactAmount",
+            "columnName": "exact_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_selected_investments_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_selected_investments_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          },
+          {
+            "name": "index_selected_investments_investment_id",
+            "unique": false,
+            "columnNames": [
+              "investment_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_selected_investments_investment_id` ON `${TABLE_NAME}` (`investment_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "akilimo_users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "investment_amounts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "investment_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "starch_factories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER, `factory_name` TEXT, `factory_label` TEXT, `country_code` TEXT, `is_active` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "factory_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "factory_label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "country_code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_starch_factories_factory_name_country_code",
+            "unique": true,
+            "columnNames": [
+              "factory_name",
+              "country_code"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_starch_factories_factory_name_country_code` ON `${TABLE_NAME}` (`factory_name`, `country_code`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cassava_market_prices",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `country_code` TEXT NOT NULL, `currency_code` TEXT NOT NULL, `currency_symbol` TEXT NOT NULL, `min_local_price` REAL NOT NULL, `max_local_price` REAL NOT NULL, `average_price` REAL NOT NULL, `exact_price` INTEGER NOT NULL, `item_tag` TEXT NOT NULL, `min_allowed_price` REAL NOT NULL, `max_allowed_price` REAL NOT NULL, `active` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "country_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currency_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencySymbol",
+            "columnName": "currency_symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minLocalPrice",
+            "columnName": "min_local_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxLocalPrice",
+            "columnName": "max_local_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averagePrice",
+            "columnName": "average_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactPrice",
+            "columnName": "exact_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemTag",
+            "columnName": "item_tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAllowedPrice",
+            "columnName": "min_allowed_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxAllowedPrice",
+            "columnName": "max_allowed_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "selected_cassava_markets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `user_id` INTEGER NOT NULL, `market_price_id` INTEGER, `starch_factory_id` INTEGER, `cassava_unit_id` INTEGER, `yield_id` INTEGER, `produce_type` TEXT NOT NULL, `unit_of_sale` TEXT NOT NULL, `unit_price` REAL NOT NULL, `unit_price_p1` REAL NOT NULL, `unit_price_p2` REAL NOT NULL, `unit_price_m1` REAL NOT NULL, `unit_price_m2` REAL NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `akilimo_users`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`market_price_id`) REFERENCES `cassava_market_prices`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`cassava_unit_id`) REFERENCES `cassava_units`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`starch_factory_id`) REFERENCES `starch_factories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`yield_id`) REFERENCES `cassava_yields`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marketPriceId",
+            "columnName": "market_price_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "starchFactoryId",
+            "columnName": "starch_factory_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cassavaUnitId",
+            "columnName": "cassava_unit_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "yieldId",
+            "columnName": "yield_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "produceType",
+            "columnName": "produce_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitOfSale",
+            "columnName": "unit_of_sale",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPrice",
+            "columnName": "unit_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPriceP1",
+            "columnName": "unit_price_p1",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPriceP2",
+            "columnName": "unit_price_p2",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPriceM1",
+            "columnName": "unit_price_m1",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPriceM2",
+            "columnName": "unit_price_m2",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_selected_cassava_markets_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_selected_cassava_markets_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          },
+          {
+            "name": "index_selected_cassava_markets_starch_factory_id",
+            "unique": false,
+            "columnNames": [
+              "starch_factory_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_selected_cassava_markets_starch_factory_id` ON `${TABLE_NAME}` (`starch_factory_id`)"
+          },
+          {
+            "name": "index_selected_cassava_markets_market_price_id",
+            "unique": false,
+            "columnNames": [
+              "market_price_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_selected_cassava_markets_market_price_id` ON `${TABLE_NAME}` (`market_price_id`)"
+          },
+          {
+            "name": "index_selected_cassava_markets_cassava_unit_id",
+            "unique": false,
+            "columnNames": [
+              "cassava_unit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_selected_cassava_markets_cassava_unit_id` ON `${TABLE_NAME}` (`cassava_unit_id`)"
+          },
+          {
+            "name": "index_selected_cassava_markets_yield_id",
+            "unique": false,
+            "columnNames": [
+              "yield_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_selected_cassava_markets_yield_id` ON `${TABLE_NAME}` (`yield_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "akilimo_users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "cassava_market_prices",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "market_price_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "cassava_units",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cassava_unit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "starch_factories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "starch_factory_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "cassava_yields",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "yield_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "produce_markets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `user_id` INTEGER NOT NULL, `unit_price` REAL NOT NULL, `market_type` TEXT NOT NULL, `produce_type` TEXT NOT NULL, `unit_of_sale` TEXT NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `akilimo_users`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPrice",
+            "columnName": "unit_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marketType",
+            "columnName": "market_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "produceType",
+            "columnName": "produce_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitOfSale",
+            "columnName": "unit_of_sale",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_produce_markets_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_produce_markets_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          },
+          {
+            "name": "index_produce_markets_user_id_market_type",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "market_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_produce_markets_user_id_market_type` ON `${TABLE_NAME}` (`user_id`, `market_type`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "akilimo_users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cassava_units",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `unit_weight` REAL NOT NULL, `sort_order` INTEGER NOT NULL, `label` TEXT NOT NULL, `description` TEXT, `is_active` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitWeight",
+            "columnName": "unit_weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cassava_yields",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `yield_amount` REAL NOT NULL, `image_res` INTEGER NOT NULL, `yield_label` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "yieldAmount",
+            "columnName": "yield_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageRes",
+            "columnName": "image_res",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "yieldLabel",
+            "columnName": "yield_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cassava_yields_yield_label",
+            "unique": true,
+            "columnNames": [
+              "yield_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cassava_yields_yield_label` ON `${TABLE_NAME}` (`yield_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "advice_completions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`task_name` TEXT NOT NULL, `step_status` TEXT NOT NULL, `competed_at` INTEGER, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`task_name`))",
+        "fields": [
+          {
+            "fieldPath": "taskName",
+            "columnName": "task_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stepStatus",
+            "columnName": "step_status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAtMillis",
+            "columnName": "competed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "task_name"
+          ]
+        }
+      },
+      {
+        "tableName": "field_operation_costs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` INTEGER NOT NULL, `cost_lmo_area_basis` TEXT NOT NULL, `manual_plough_cost` REAL NOT NULL, `manual_ridge_cost` REAL NOT NULL, `manual_harrow_cost` REAL NOT NULL, `exact_manual_plough_price` INTEGER NOT NULL, `exact_manual_ridge_price` INTEGER NOT NULL, `exact_manual_harrow_price` INTEGER NOT NULL, `tractor_available` INTEGER NOT NULL, `tractor_plough_cost` REAL NOT NULL, `tractor_ridge_cost` REAL NOT NULL, `tractor_harrow_cost` REAL NOT NULL, `exact_tractor_plough_price` INTEGER NOT NULL, `exact_tractor_ridge_price` INTEGER NOT NULL, `exact_tractor_harrow_price` INTEGER NOT NULL, `first_weeding_operation_cost` REAL NOT NULL, `second_weeding_operation_cost` REAL NOT NULL, `exact_first_weeding_price` INTEGER NOT NULL, `exact_second_weeding_price` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`user_id`), FOREIGN KEY(`user_id`) REFERENCES `akilimo_users`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "costLmoAreaBasis",
+            "columnName": "cost_lmo_area_basis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manualPloughCost",
+            "columnName": "manual_plough_cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manualRidgeCost",
+            "columnName": "manual_ridge_cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manualHarrowCost",
+            "columnName": "manual_harrow_cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactManualPloughPrice",
+            "columnName": "exact_manual_plough_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactManualRidgePrice",
+            "columnName": "exact_manual_ridge_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactManualHarrowPrice",
+            "columnName": "exact_manual_harrow_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tractorAvailable",
+            "columnName": "tractor_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tractorPloughCost",
+            "columnName": "tractor_plough_cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tractorRidgeCost",
+            "columnName": "tractor_ridge_cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tractorHarrowCost",
+            "columnName": "tractor_harrow_cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactTractorPloughPrice",
+            "columnName": "exact_tractor_plough_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactTractorRidgePrice",
+            "columnName": "exact_tractor_ridge_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactTractorHarrowPrice",
+            "columnName": "exact_tractor_harrow_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstWeedingOperationCost",
+            "columnName": "first_weeding_operation_cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secondWeedingOperationCost",
+            "columnName": "second_weeding_operation_cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactFirstWeedingPrice",
+            "columnName": "exact_first_weeding_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exactSecondWeedingPrice",
+            "columnName": "exact_second_weeding_price",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "user_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_field_operation_costs_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_field_operation_costs_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "akilimo_users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "current_practices",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `user_id` INTEGER NOT NULL, `weed_radio_index` INTEGER NOT NULL, `weed_control_method` TEXT, `plough_operations` TEXT, `ridge_operations` TEXT, `harrow_operations` TEXT, `weed_control_operations` TEXT, `ploughing_method` TEXT, `ridging_method` TEXT, `harrowing_method` TEXT, `tractor_available` INTEGER NOT NULL, `tractor_plough` INTEGER NOT NULL, `tractor_harrow` INTEGER NOT NULL, `tractor_ridger` INTEGER NOT NULL, `uses_herbicide` INTEGER NOT NULL, `perform_ploughing` INTEGER NOT NULL, `perform_harrowing` INTEGER NOT NULL, `perform_ridging` INTEGER NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `akilimo_users`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weedRadioIndex",
+            "columnName": "weed_radio_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weedControlMethod",
+            "columnName": "weed_control_method",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ploughOperations",
+            "columnName": "plough_operations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ridgeOperations",
+            "columnName": "ridge_operations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "harrowOperations",
+            "columnName": "harrow_operations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "weedControlOperations",
+            "columnName": "weed_control_operations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ploughingMethod",
+            "columnName": "ploughing_method",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ridgingMethod",
+            "columnName": "ridging_method",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "harrowingMethod",
+            "columnName": "harrowing_method",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tractorAvailable",
+            "columnName": "tractor_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tractorPlough",
+            "columnName": "tractor_plough",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tractorHarrow",
+            "columnName": "tractor_harrow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tractorRidger",
+            "columnName": "tractor_ridger",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usesHerbicide",
+            "columnName": "uses_herbicide",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "performPloughing",
+            "columnName": "perform_ploughing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "performHarrowing",
+            "columnName": "perform_harrowing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "performRidging",
+            "columnName": "perform_ridging",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_current_practices_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_current_practices_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "akilimo_users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "maize_performance",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `user_id` INTEGER NOT NULL, `maize_performance` TEXT NOT NULL, `created_at` INTEGER, `updated_at` INTEGER NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `akilimo_users`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maizePerformance",
+            "columnName": "maize_performance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_maize_performance_user_id",
+            "unique": true,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_maize_performance_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "akilimo_users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `language_code` TEXT NOT NULL, `first_name` TEXT, `last_name` TEXT, `email` TEXT, `phone_number` TEXT, `phone_country_code` TEXT, `gender` TEXT, `country` TEXT NOT NULL, `bio` TEXT, `notify_by_email` INTEGER NOT NULL, `notify_by_sms` INTEGER NOT NULL, `preferred_area_unit` TEXT NOT NULL, `dark_mode` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languageCode",
+            "columnName": "language_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "first_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "last_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phone_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phoneCountryCode",
+            "columnName": "phone_country_code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bio",
+            "columnName": "bio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notifyByEmail",
+            "columnName": "notify_by_email",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notifyBySms",
+            "columnName": "notify_by_sms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preferredAreaUnit",
+            "columnName": "preferred_area_unit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkMode",
+            "columnName": "dark_mode",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '58bb8fd579df74a299ed0d9f34ce0f56')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/akilimo/mobile/HiltTestRunner.kt
+++ b/app/src/androidTest/java/com/akilimo/mobile/HiltTestRunner.kt
@@ -1,0 +1,20 @@
+package com.akilimo.mobile
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+/**
+ * Custom test runner that replaces the application class with [HiltTestApplication]
+ * so that Hilt's dependency injection works in all @HiltAndroidTest instrumented tests.
+ *
+ * Referenced by testInstrumentationRunner in build.gradle.kts.
+ */
+class HiltTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(
+        cl: ClassLoader?,
+        name: String?,
+        context: Context?
+    ): Application = super.newApplication(cl, HiltTestApplication::class.java.name, context)
+}

--- a/app/src/androidTest/java/com/akilimo/mobile/dao/AdviceCompletionDaoTest.kt
+++ b/app/src/androidTest/java/com/akilimo/mobile/dao/AdviceCompletionDaoTest.kt
@@ -1,0 +1,130 @@
+package com.akilimo.mobile.dao
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.akilimo.mobile.database.AppDatabase
+import com.akilimo.mobile.entities.AdviceCompletion
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumStepStatus
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented DAO tests using an in-memory Room database.
+ *
+ * Guards the [AdviceCompletionDao] contract which drives the step-status
+ * completion indicators shown on recommendation sub-screens.
+ */
+@RunWith(AndroidJUnit4::class)
+class AdviceCompletionDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: AdviceCompletionDao
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.adviceCompletionDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    @Test
+    fun getAllFlow_emitsEmptyListInitially() = runBlocking {
+        val results = dao.getAllFlow().first()
+        assertEquals(0, results.size)
+    }
+
+    @Test
+    fun upsert_insertsRecord_visibleViaFlow() = runBlocking {
+        val entity = AdviceCompletion(
+            taskName = EnumAdviceTask.AVAILABLE_FERTILIZERS,
+            stepStatus = EnumStepStatus.COMPLETED
+        )
+
+        dao.upsert(entity)
+
+        val results = dao.getAllFlow().first()
+        assertEquals(1, results.size)
+        assertEquals(EnumStepStatus.COMPLETED, results.first().stepStatus)
+    }
+
+    @Test
+    fun upsert_updatesExistingRecord() = runBlocking {
+        dao.upsert(
+            AdviceCompletion(
+                taskName = EnumAdviceTask.AVAILABLE_FERTILIZERS,
+                stepStatus = EnumStepStatus.IN_PROGRESS
+            )
+        )
+
+        dao.upsert(
+            AdviceCompletion(
+                taskName = EnumAdviceTask.AVAILABLE_FERTILIZERS,
+                stepStatus = EnumStepStatus.COMPLETED
+            )
+        )
+
+        val results = dao.getAllFlow().first()
+        assertEquals(1, results.size)                          // still one row
+        assertEquals(EnumStepStatus.COMPLETED, results.first().stepStatus)
+    }
+
+    @Test
+    fun upsert_multipleDistinctTasks_allPersisted() = runBlocking {
+        dao.upsert(AdviceCompletion(EnumAdviceTask.AVAILABLE_FERTILIZERS, EnumStepStatus.COMPLETED))
+        dao.upsert(AdviceCompletion(EnumAdviceTask.PLANTING_AND_HARVEST, EnumStepStatus.IN_PROGRESS))
+        dao.upsert(AdviceCompletion(EnumAdviceTask.CASSAVA_MARKET_OUTLET, EnumStepStatus.NOT_STARTED))
+
+        val results = dao.getAllFlow().first()
+        assertEquals(3, results.size)
+    }
+
+    @Test
+    fun getAdviceByTask_returnsCorrectRecord() = runBlocking {
+        dao.upsert(AdviceCompletion(EnumAdviceTask.AVAILABLE_FERTILIZERS, EnumStepStatus.COMPLETED))
+        dao.upsert(AdviceCompletion(EnumAdviceTask.PLANTING_AND_HARVEST, EnumStepStatus.IN_PROGRESS))
+
+        val result = dao.getAdviceByTask(EnumAdviceTask.PLANTING_AND_HARVEST)
+
+        assertEquals(EnumAdviceTask.PLANTING_AND_HARVEST, result?.taskName)
+        assertEquals(EnumStepStatus.IN_PROGRESS, result?.stepStatus)
+    }
+
+    @Test
+    fun getAdviceByTask_returnsNullForMissingTask() = runBlocking {
+        val result = dao.getAdviceByTask(EnumAdviceTask.AVAILABLE_FERTILIZERS)
+        assertNull(result)
+    }
+
+    @Test
+    fun delete_removesOnlyTargetTask() = runBlocking {
+        dao.upsert(AdviceCompletion(EnumAdviceTask.AVAILABLE_FERTILIZERS, EnumStepStatus.COMPLETED))
+        dao.upsert(AdviceCompletion(EnumAdviceTask.PLANTING_AND_HARVEST, EnumStepStatus.COMPLETED))
+
+        dao.delete(EnumAdviceTask.AVAILABLE_FERTILIZERS)
+
+        val results = dao.getAllFlow().first()
+        assertEquals(1, results.size)
+        assertEquals(EnumAdviceTask.PLANTING_AND_HARVEST, results.first().taskName)
+    }
+
+    @Test
+    fun delete_nonExistentTask_doesNotThrow() = runBlocking {
+        dao.delete(EnumAdviceTask.AVAILABLE_FERTILIZERS) // no-op, must not crash
+
+        val results = dao.getAllFlow().first()
+        assertEquals(0, results.size)
+    }
+}

--- a/app/src/androidTest/java/com/akilimo/mobile/ui/activities/RecommendationsBackNavigationTest.kt
+++ b/app/src/androidTest/java/com/akilimo/mobile/ui/activities/RecommendationsBackNavigationTest.kt
@@ -1,0 +1,121 @@
+package com.akilimo.mobile.ui.activities
+
+import androidx.navigation.findNavController
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.akilimo.mobile.R
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented regression tests for back navigation in the recommendations graph.
+ *
+ * These tests directly catch the bug where BaseActivity's OnBackPressedCallback
+ * (registered after NavHostFragment's, so LIFO-wins) was calling finish() on every
+ * system back press instead of delegating to NavController.
+ *
+ * Regression: if handleBackPressed() is removed from RecommendationsActivity,
+ * pressBack() from a sub-screen will finish the Activity instead of popping to
+ * the previous destination.
+ *
+ * No @HiltAndroidTest needed — we don't inject into the test class.
+ * HiltTestRunner already provides HiltTestApplication so @AndroidEntryPoint
+ * components in the launched Activity work without further setup here.
+ */
+@RunWith(AndroidJUnit4::class)
+class RecommendationsBackNavigationTest {
+
+    @Test
+    fun pressBack_fromFrFragment_returnsToRecommendationsFragment() {
+        ActivityScenario.launch(RecommendationsActivity::class.java).use { scenario ->
+            // Navigate to the FR sub-screen
+            scenario.onActivity { activity ->
+                activity.findNavController(R.id.nav_host_recommendations)
+                    .navigate(R.id.action_recommendations_to_fr)
+            }
+
+            // Simulate system back press
+            pressBack()
+
+            // Must land on the summary screen, not finish the Activity
+            scenario.onActivity { activity ->
+                val current = activity.findNavController(R.id.nav_host_recommendations)
+                    .currentDestination?.id
+                assertEquals(
+                    "Back from FrFragment should return to RecommendationsFragment",
+                    R.id.recommendationsFragment, current
+                )
+            }
+        }
+    }
+
+    @Test
+    fun pressBack_fromBppFragment_returnsToRecommendationsFragment() {
+        ActivityScenario.launch(RecommendationsActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findNavController(R.id.nav_host_recommendations)
+                    .navigate(R.id.action_recommendations_to_bpp)
+            }
+
+            pressBack()
+
+            scenario.onActivity { activity ->
+                val current = activity.findNavController(R.id.nav_host_recommendations)
+                    .currentDestination?.id
+                assertEquals(R.id.recommendationsFragment, current)
+            }
+        }
+    }
+
+    @Test
+    fun pressBack_fromSphFragment_returnsToRecommendationsFragment() {
+        ActivityScenario.launch(RecommendationsActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findNavController(R.id.nav_host_recommendations)
+                    .navigate(R.id.action_recommendations_to_sph)
+            }
+
+            pressBack()
+
+            scenario.onActivity { activity ->
+                val current = activity.findNavController(R.id.nav_host_recommendations)
+                    .currentDestination?.id
+                assertEquals(R.id.recommendationsFragment, current)
+            }
+        }
+    }
+
+    @Test
+    fun pressBack_fromIcMaizeFragment_returnsToRecommendationsFragment() {
+        ActivityScenario.launch(RecommendationsActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findNavController(R.id.nav_host_recommendations)
+                    .navigate(R.id.action_recommendations_to_icMaize)
+            }
+
+            pressBack()
+
+            scenario.onActivity { activity ->
+                val current = activity.findNavController(R.id.nav_host_recommendations)
+                    .currentDestination?.id
+                assertEquals(R.id.recommendationsFragment, current)
+            }
+        }
+    }
+
+    @Test
+    fun pressBack_atRecommendationsFragment_finishesActivity() {
+        ActivityScenario.launch(RecommendationsActivity::class.java).use { scenario ->
+            // At start destination — back should finish the Activity
+            pressBack()
+
+            // ActivityScenario.getState() returns DESTROYED when the activity finishes
+            assertEquals(
+                androidx.lifecycle.Lifecycle.State.DESTROYED,
+                scenario.state
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/base/AbstractProduceMarketFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/base/AbstractProduceMarketFragment.kt
@@ -1,0 +1,187 @@
+package com.akilimo.mobile.base
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import androidx.viewbinding.ViewBinding
+import com.akilimo.mobile.R
+import com.akilimo.mobile.adapters.BaseValueOptionAdapter
+import com.akilimo.mobile.dto.UnitOfSaleOption
+import com.akilimo.mobile.entities.ProduceMarket
+import com.akilimo.mobile.enums.EnumMarketType
+import com.akilimo.mobile.enums.EnumProduceType
+import com.akilimo.mobile.enums.EnumUnitOfSale
+import com.akilimo.mobile.ui.components.ProduceMarketViews
+import com.akilimo.mobile.ui.components.ToolbarHelper
+import com.akilimo.mobile.ui.viewmodels.ProduceMarketViewModel
+import dagger.hilt.android.lifecycle.withCreationCallback
+import kotlinx.coroutines.launch
+
+/**
+ * Base fragment for produce market screens.
+ *
+ * Mirrors [AbstractProduceMarketActivity] but hosted inside the NavGraph.
+ * On save it pops the back stack — no Fragment Result is sent because the market
+ * step status is tracked via the database, not via a result DTO.
+ */
+abstract class AbstractProduceMarketFragment<VB : ViewBinding>(
+    private val marketType: EnumMarketType,
+    private val titleRes: Int
+) : BaseFragment<VB>() {
+
+    protected val viewModel: ProduceMarketViewModel by viewModels(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<ProduceMarketViewModel.Factory> { factory ->
+                factory.create(marketType)
+            }
+        }
+    )
+
+    protected var currencyCode: String = ""
+
+    protected abstract val views: ProduceMarketViews
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        setupToolbar()
+        setupInitialVisibility()
+        setupProduceTypeSelection()
+        observeViewModel()
+        viewModel.loadData(sessionManager.akilimoUser)
+    }
+
+    private fun observeViewModel() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    if (state.saved) {
+                        viewModel.onSaveHandled()
+                        findNavController().popBackStack()
+                        return@collect
+                    }
+
+                    if (state.userId == 0) return@collect
+
+                    currencyCode = state.currencyCode
+                    views.priceInputLayout.prefixText = "$currencyCode "
+
+                    state.lastEntry?.let { entry ->
+                        updateUnits { unit ->
+                            if (entry.produceType == EnumProduceType.MAIZE_FRESH_COB)
+                                unit == EnumUnitOfSale.FRESH_COB
+                            else
+                                unit.isUniversal
+                        }
+                        views.apply {
+                            inputPrice.setText(entry.unitPrice.toString())
+                            unitSpinner.setText(
+                                entry.unitOfSale.unitOfSale(requireContext()),
+                                false
+                            )
+                            marketHintText.text = getString(R.string.lbl_selling_hint)
+                                .replace("{currency}", currencyCode)
+                                .replace("{price}", entry.unitPrice.toString())
+                                .replace(
+                                    "{unit_of_sale}",
+                                    entry.unitOfSale.unitOfSale(requireContext())
+                                )
+                            marketHintCard.isVisible = true
+                        }
+                        onEntryPrefilled(entry)
+                    }
+                }
+            }
+        }
+    }
+
+    protected open fun onEntryPrefilled(entry: ProduceMarket) = Unit
+
+    private fun setupToolbar() {
+        ToolbarHelper(requireActivity() as AppCompatActivity, views.toolbar)
+            .setTitle(getString(titleRes))
+            .onNavigationClick { findNavController().popBackStack() }
+            .build()
+    }
+
+    private fun setupInitialVisibility() = with(views) {
+        fabSave.isVisible = false
+        unitLabel.isVisible = true
+        unitInputLayout.isVisible = true
+    }
+
+    protected abstract fun setupProduceTypeSelection()
+
+    protected fun updateUnits(filter: (EnumUnitOfSale) -> Boolean) {
+        val filtered = EnumUnitOfSale.entries
+            .filter(filter)
+            .map { UnitOfSaleOption(valueOption = it) }
+        val unitAdapter = BaseValueOptionAdapter(requireContext(), filtered) { it.label(requireContext()) }
+        views.apply {
+            unitSpinner.setAdapter(unitAdapter)
+
+            inputPrice.addTextChangedListener { validateForm() }
+
+            unitSpinner.setOnItemClickListener { _, _, position, _ ->
+                val selected = unitAdapter.getItem(position) ?: return@setOnItemClickListener
+                unitSpinner.setText(
+                    selected.valueOption.unitOfSale(requireContext()),
+                    false
+                )
+                validateForm()
+            }
+
+            fabSave.setOnClickListener { saveMarketEntry() }
+        }
+    }
+
+    private val enteredPrice: Double?
+        get() = views.inputPrice.text?.toString()?.toDoubleOrNull()
+
+    protected fun validateForm() = with(views) {
+        fabSave.isVisible =
+            enteredPrice?.let { it > 0 } == true && !unitSpinner.text.isNullOrEmpty()
+    }
+
+    private fun saveMarketEntry() {
+        clearErrors()
+
+        val price = enteredPrice ?: return showPriceError()
+        val unit = selectedUnit() ?: return showUnitError()
+
+        val userId = viewModel.uiState.value.userId.takeIf { it != 0 } ?: return
+        viewModel.saveMarketEntry(
+            ProduceMarket(
+                userId = userId,
+                unitPrice = price,
+                marketType = marketType,
+                produceType = resolveProduceType(),
+                unitOfSale = unit
+            )
+        )
+    }
+
+    private fun selectedUnit(): EnumUnitOfSale? =
+        EnumUnitOfSale.entries.firstOrNull {
+            it.unitOfSale(requireContext()) == views.unitSpinner.text.toString()
+        }
+
+    private fun showPriceError() = with(views) {
+        priceInputLayout.error = getString(R.string.lbl_invalid_grain_price)
+    }
+
+    private fun showUnitError() = with(views) {
+        unitInputLayout.error = getString(R.string.lbl_invalid_sale_unit)
+    }
+
+    private fun clearErrors() = with(views) {
+        unitInputLayout.error = null
+        priceInputLayout.error = null
+    }
+
+    protected abstract fun resolveProduceType(): EnumProduceType
+}

--- a/app/src/main/java/com/akilimo/mobile/base/AbstractRecommendationFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/base/AbstractRecommendationFragment.kt
@@ -55,7 +55,7 @@ abstract class AbstractRecommendationFragment :
 
     override fun onBindingReady(savedInstanceState: Bundle?) {
         ToolbarHelper(requireActivity() as androidx.appcompat.app.AppCompatActivity, binding.lytToolbar.toolbar)
-            .onNavigationClick { requireActivity().onBackPressedDispatcher.onBackPressed() }
+            .onNavigationClick { findNavController().popBackStack() }
             .build()
 
         val recAdapter = createRecommendationAdapter()

--- a/app/src/main/java/com/akilimo/mobile/base/AbstractRecommendationFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/base/AbstractRecommendationFragment.kt
@@ -1,13 +1,12 @@
 package com.akilimo.mobile.base
 
-import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.IntentCompat
+import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.akilimo.mobile.R
 import com.akilimo.mobile.adapters.RecommendationAdapter
@@ -19,8 +18,9 @@ import com.akilimo.mobile.enums.EnumAdviceTask
 import com.akilimo.mobile.enums.EnumRecyclerLayout
 import com.akilimo.mobile.enums.EnumStepStatus
 import com.akilimo.mobile.enums.EnumUseCase
-import com.akilimo.mobile.ui.activities.GetRecommendationActivity
 import com.akilimo.mobile.ui.components.ToolbarHelper
+import com.akilimo.mobile.ui.fragments.usecases.GetRecommendationFragment
+import com.akilimo.mobile.ui.fragments.usecases.UseCaseResults
 import com.akilimo.mobile.ui.viewmodels.AdviceCompletionViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -30,12 +30,12 @@ import kotlinx.coroutines.launch
  * Base fragment for recommendation use-case screens.
  *
  * Mirrors [AbstractRecommendationActivity] but hosted inside the NavGraph.
- * Use-case activities are still launched via [registerForActivityResult]; results
- * are forwarded to [AdviceCompletionViewModel].
+ * Use-case screens are launched as Fragments via [findNavController]; results
+ * are received via the Fragment Result API and forwarded to [AdviceCompletionViewModel].
  *
  * Subclasses MUST:
  *  [1] Provide advice options via [getAdviceOptions]
- *  [2] Map tasks to Intents via [mapTaskToIntent]
+ *  [2] Map tasks to nav destination IDs via [mapTaskToDestination]
  *  [3] Provide the [EnumUseCase] for the "Get Recommendation" action via [enumUseCase]
  */
 @AndroidEntryPoint
@@ -65,11 +65,20 @@ abstract class AbstractRecommendationFragment :
         }
 
         binding.frButton.btnAction.setOnClickListener {
-            startActivity(
-                Intent(requireContext(), GetRecommendationActivity::class.java).apply {
-                    putExtra(GetRecommendationActivity.EXTRA_USE_CASE, enumUseCase as Parcelable)
-                }
+            findNavController().navigate(
+                R.id.getRecommendationFragment,
+                bundleOf(GetRecommendationFragment.ARG_USE_CASE to enumUseCase as Parcelable)
             )
+        }
+
+        // Receive AdviceCompletionDto results from use-case fragments
+        parentFragmentManager.setFragmentResultListener(
+            UseCaseResults.ADVICE_COMPLETION,
+            viewLifecycleOwner
+        ) { _, bundle ->
+            @Suppress("DEPRECATION")
+            (bundle.getParcelable<AdviceCompletionDto>(UseCaseResults.ADVICE_COMPLETION_DTO))
+                ?.let { adviceViewModel.updateStatus(it) }
         }
 
         safeScope.launch {
@@ -86,15 +95,6 @@ abstract class AbstractRecommendationFragment :
         }
     }
 
-    private val launcher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            result.data?.let {
-                IntentCompat.getParcelableExtra(it, BaseActivity.COMPLETED_TASK, AdviceCompletionDto::class.java)
-            }?.let { dto ->
-                adviceViewModel.updateStatus(dto)
-            }
-        }
-
     protected open fun createRecommendationAdapter(
         layout: EnumRecyclerLayout = currentLayout
     ): RecommendationAdapter<UseCaseOption> {
@@ -104,7 +104,9 @@ abstract class AbstractRecommendationFragment :
             getId = { it.valueOption.name },
             stepStatus = { it.stepStatus },
             onClick = { item ->
-                mapTaskToIntent(item.valueOption.valueOption)?.let { launcher.launch(it) }
+                mapTaskToDestination(item.valueOption.valueOption)?.let { destId ->
+                    findNavController().navigate(destId)
+                }
             }
         )
         binding.fertilizerRecList.layoutManager = when (layout) {
@@ -116,5 +118,10 @@ abstract class AbstractRecommendationFragment :
     }
 
     abstract fun getAdviceOptions(): List<UseCaseOption>
-    abstract fun mapTaskToIntent(task: EnumAdviceTask): Intent?
+
+    /**
+     * Map [task] to a navigation destination ID in nav_recommendations.xml.
+     * Return null for tasks that have no navigation target.
+     */
+    abstract fun mapTaskToDestination(task: EnumAdviceTask): Int?
 }

--- a/app/src/main/java/com/akilimo/mobile/database/AppDatabase.kt
+++ b/app/src/main/java/com/akilimo/mobile/database/AppDatabase.kt
@@ -73,7 +73,7 @@ import com.akilimo.mobile.utils.EnumWeedControlConverter
         MaizePerformance::class,
         UserPreferences::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 @TypeConverters(
@@ -142,7 +142,8 @@ abstract class AppDatabase : RoomDatabase() {
             )
                 .addMigrations(
                     DatabaseMigrations.MIGRATION_2_3,
-                    DatabaseMigrations.MIGRATION_3_4
+                    DatabaseMigrations.MIGRATION_3_4,
+                    DatabaseMigrations.MIGRATION_4_5
                 )
                 .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
                 .build()

--- a/app/src/main/java/com/akilimo/mobile/database/DatabaseMigrations.kt
+++ b/app/src/main/java/com/akilimo/mobile/database/DatabaseMigrations.kt
@@ -27,4 +27,15 @@ object DatabaseMigrations {
             db.execSQL("ALTER TABLE akilimo_users ADD COLUMN last_sync_at INTEGER DEFAULT NULL")
         }
     }
+
+    /**
+     * v4 → v5: Add weed_control_method column to akilimo_users.
+     * Captures the weeding method selected during onboarding so it
+     * pre-fills the BPP weed-control use-case screen.
+     */
+    val MIGRATION_4_5 = object : Migration(4, 5) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE akilimo_users ADD COLUMN weed_control_method TEXT DEFAULT NULL")
+        }
+    }
 }

--- a/app/src/main/java/com/akilimo/mobile/entities/AkilimoUser.kt
+++ b/app/src/main/java/com/akilimo/mobile/entities/AkilimoUser.kt
@@ -9,6 +9,7 @@ import com.akilimo.mobile.enums.EnumAdvice
 import com.akilimo.mobile.enums.EnumAreaUnit
 import com.akilimo.mobile.enums.EnumCountry
 import com.akilimo.mobile.enums.EnumInvestmentPref
+import com.akilimo.mobile.enums.EnumWeedControlMethod
 import java.time.LocalDate
 import java.util.Locale
 
@@ -108,6 +109,9 @@ data class AkilimoUser(
 
     @ColumnInfo(name = "tillage_operations")
     val tillageOperations: List<OperationEntry> = emptyList(),
+
+    @ColumnInfo(name = "weed_control_method")
+    val weedControlMethod: EnumWeedControlMethod? = null,
 
     @ColumnInfo(name = "investment_preferences")
     val investmentPref: EnumInvestmentPref? = null,

--- a/app/src/main/java/com/akilimo/mobile/ui/activities/RecommendationsActivity.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/activities/RecommendationsActivity.kt
@@ -1,6 +1,8 @@
 package com.akilimo.mobile.ui.activities
 
 import android.os.Bundle
+import androidx.navigation.findNavController
+import com.akilimo.mobile.R
 import com.akilimo.mobile.base.BaseActivity
 import com.akilimo.mobile.databinding.ActivityRecommendationsBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -17,4 +19,12 @@ class RecommendationsActivity : BaseActivity<ActivityRecommendationsBinding>() {
     override fun onBindingReady(savedInstanceState: Bundle?) {
         // NavHostFragment in the layout auto-starts RecommendationsFragment
     }
+
+    /**
+     * Delegate back presses to the NavController so that system back navigates
+     * within the recommendations graph instead of finishing the Activity.
+     * Returns false (→ finish()) only when the back stack is exhausted.
+     */
+    override fun handleBackPressed(): Boolean =
+        findNavController(R.id.nav_host_recommendations).popBackStack()
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/BppFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/BppFragment.kt
@@ -1,16 +1,10 @@
 package com.akilimo.mobile.ui.fragments
 
-import android.content.Intent
+import com.akilimo.mobile.R
 import com.akilimo.mobile.base.AbstractRecommendationFragment
 import com.akilimo.mobile.dto.UseCaseOption
 import com.akilimo.mobile.enums.EnumAdviceTask
 import com.akilimo.mobile.enums.EnumUseCase
-import com.akilimo.mobile.ui.usecases.CassavaMarketActivity
-import com.akilimo.mobile.ui.usecases.CassavaYieldActivity
-import com.akilimo.mobile.ui.usecases.DatesActivity
-import com.akilimo.mobile.ui.usecases.ManualTillageCostActivity
-import com.akilimo.mobile.ui.usecases.TractorAccessActivity
-import com.akilimo.mobile.ui.usecases.WeedControlCostsActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -27,13 +21,13 @@ class BppFragment : AbstractRecommendationFragment() {
         UseCaseOption(EnumAdviceTask.COST_OF_WEED_CONTROL)
     )
 
-    override fun mapTaskToIntent(task: EnumAdviceTask): Intent? = when (task) {
-        EnumAdviceTask.PLANTING_AND_HARVEST -> Intent(requireContext(), DatesActivity::class.java)
-        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> Intent(requireContext(), CassavaMarketActivity::class.java)
-        EnumAdviceTask.CURRENT_CASSAVA_YIELD -> Intent(requireContext(), CassavaYieldActivity::class.java)
-        EnumAdviceTask.MANUAL_TILLAGE_COST -> Intent(requireContext(), ManualTillageCostActivity::class.java)
-        EnumAdviceTask.TRACTOR_ACCESS -> Intent(requireContext(), TractorAccessActivity::class.java)
-        EnumAdviceTask.COST_OF_WEED_CONTROL -> Intent(requireContext(), WeedControlCostsActivity::class.java)
+    override fun mapTaskToDestination(task: EnumAdviceTask): Int? = when (task) {
+        EnumAdviceTask.PLANTING_AND_HARVEST -> R.id.datesFragment
+        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> R.id.cassavaMarketFragment
+        EnumAdviceTask.CURRENT_CASSAVA_YIELD -> R.id.cassavaYieldFragment
+        EnumAdviceTask.MANUAL_TILLAGE_COST -> R.id.manualTillageCostFragment
+        EnumAdviceTask.TRACTOR_ACCESS -> R.id.tractorAccessFragment
+        EnumAdviceTask.COST_OF_WEED_CONTROL -> R.id.weedControlCostsFragment
         else -> null
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/FrFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/FrFragment.kt
@@ -1,14 +1,10 @@
 package com.akilimo.mobile.ui.fragments
 
-import android.content.Intent
+import com.akilimo.mobile.R
 import com.akilimo.mobile.base.AbstractRecommendationFragment
 import com.akilimo.mobile.dto.UseCaseOption
 import com.akilimo.mobile.enums.EnumAdviceTask
 import com.akilimo.mobile.enums.EnumUseCase
-import com.akilimo.mobile.ui.usecases.CassavaMarketActivity
-import com.akilimo.mobile.ui.usecases.CassavaYieldActivity
-import com.akilimo.mobile.ui.usecases.FertilizersActivity
-import com.akilimo.mobile.ui.usecases.InvestmentAmountActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -23,11 +19,11 @@ class FrFragment : AbstractRecommendationFragment() {
         UseCaseOption(EnumAdviceTask.CURRENT_CASSAVA_YIELD)
     )
 
-    override fun mapTaskToIntent(task: EnumAdviceTask): Intent? = when (task) {
-        EnumAdviceTask.AVAILABLE_FERTILIZERS -> Intent(requireContext(), FertilizersActivity::class.java)
-        EnumAdviceTask.INVESTMENT_AMOUNT -> Intent(requireContext(), InvestmentAmountActivity::class.java)
-        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> Intent(requireContext(), CassavaMarketActivity::class.java)
-        EnumAdviceTask.CURRENT_CASSAVA_YIELD -> Intent(requireContext(), CassavaYieldActivity::class.java)
+    override fun mapTaskToDestination(task: EnumAdviceTask): Int? = when (task) {
+        EnumAdviceTask.AVAILABLE_FERTILIZERS -> R.id.fertilizerFragment
+        EnumAdviceTask.INVESTMENT_AMOUNT -> R.id.investmentAmountFragment
+        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> R.id.cassavaMarketFragment
+        EnumAdviceTask.CURRENT_CASSAVA_YIELD -> R.id.cassavaYieldFragment
         else -> null
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/IcMaizeFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/IcMaizeFragment.kt
@@ -1,15 +1,10 @@
 package com.akilimo.mobile.ui.fragments
 
-import android.content.Intent
+import com.akilimo.mobile.R
 import com.akilimo.mobile.base.AbstractRecommendationFragment
 import com.akilimo.mobile.dto.UseCaseOption
 import com.akilimo.mobile.enums.EnumAdviceTask
 import com.akilimo.mobile.enums.EnumUseCase
-import com.akilimo.mobile.ui.usecases.CassavaMarketActivity
-import com.akilimo.mobile.ui.usecases.DatesActivity
-import com.akilimo.mobile.ui.usecases.InterCropFertilizersActivity
-import com.akilimo.mobile.ui.usecases.MaizeMarketActivity
-import com.akilimo.mobile.ui.usecases.MaizePerformanceActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -25,12 +20,12 @@ class IcMaizeFragment : AbstractRecommendationFragment() {
         UseCaseOption(EnumAdviceTask.MAIZE_PERFORMANCE)
     )
 
-    override fun mapTaskToIntent(task: EnumAdviceTask): Intent? = when (task) {
-        EnumAdviceTask.AVAILABLE_FERTILIZERS_CIM -> Intent(requireContext(), InterCropFertilizersActivity::class.java)
-        EnumAdviceTask.PLANTING_AND_HARVEST -> Intent(requireContext(), DatesActivity::class.java)
-        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> Intent(requireContext(), CassavaMarketActivity::class.java)
-        EnumAdviceTask.MAIZE_MARKET_OUTLET -> Intent(requireContext(), MaizeMarketActivity::class.java)
-        EnumAdviceTask.MAIZE_PERFORMANCE -> Intent(requireContext(), MaizePerformanceActivity::class.java)
+    override fun mapTaskToDestination(task: EnumAdviceTask): Int? = when (task) {
+        EnumAdviceTask.AVAILABLE_FERTILIZERS_CIM -> R.id.interCropFertilizersFragment
+        EnumAdviceTask.PLANTING_AND_HARVEST -> R.id.datesFragment
+        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> R.id.cassavaMarketFragment
+        EnumAdviceTask.MAIZE_MARKET_OUTLET -> R.id.maizeMarketFragment
+        EnumAdviceTask.MAIZE_PERFORMANCE -> R.id.maizePerformanceFragment
         else -> null
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/IcSweetPotatoFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/IcSweetPotatoFragment.kt
@@ -1,14 +1,10 @@
 package com.akilimo.mobile.ui.fragments
 
-import android.content.Intent
+import com.akilimo.mobile.R
 import com.akilimo.mobile.base.AbstractRecommendationFragment
 import com.akilimo.mobile.dto.UseCaseOption
 import com.akilimo.mobile.enums.EnumAdviceTask
 import com.akilimo.mobile.enums.EnumUseCase
-import com.akilimo.mobile.ui.usecases.CassavaMarketActivity
-import com.akilimo.mobile.ui.usecases.DatesActivity
-import com.akilimo.mobile.ui.usecases.InterCropFertilizersActivity
-import com.akilimo.mobile.ui.usecases.SweetPotatoMarketActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -23,11 +19,11 @@ class IcSweetPotatoFragment : AbstractRecommendationFragment() {
         UseCaseOption(EnumAdviceTask.SWEET_POTATO_MARKET_OUTLET)
     )
 
-    override fun mapTaskToIntent(task: EnumAdviceTask): Intent? = when (task) {
-        EnumAdviceTask.AVAILABLE_FERTILIZERS_CIS -> Intent(requireContext(), InterCropFertilizersActivity::class.java)
-        EnumAdviceTask.PLANTING_AND_HARVEST -> Intent(requireContext(), DatesActivity::class.java)
-        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> Intent(requireContext(), CassavaMarketActivity::class.java)
-        EnumAdviceTask.SWEET_POTATO_MARKET_OUTLET -> Intent(requireContext(), SweetPotatoMarketActivity::class.java)
+    override fun mapTaskToDestination(task: EnumAdviceTask): Int? = when (task) {
+        EnumAdviceTask.AVAILABLE_FERTILIZERS_CIS -> R.id.sweetPotatoInterCropFertilizersFragment
+        EnumAdviceTask.PLANTING_AND_HARVEST -> R.id.datesFragment
+        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> R.id.cassavaMarketFragment
+        EnumAdviceTask.SWEET_POTATO_MARKET_OUTLET -> R.id.sweetPotatoMarketFragment
         else -> null
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/SphFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/SphFragment.kt
@@ -1,13 +1,10 @@
 package com.akilimo.mobile.ui.fragments
 
-import android.content.Intent
+import com.akilimo.mobile.R
 import com.akilimo.mobile.base.AbstractRecommendationFragment
 import com.akilimo.mobile.dto.UseCaseOption
 import com.akilimo.mobile.enums.EnumAdviceTask
 import com.akilimo.mobile.enums.EnumUseCase
-import com.akilimo.mobile.ui.usecases.CassavaMarketActivity
-import com.akilimo.mobile.ui.usecases.CassavaYieldActivity
-import com.akilimo.mobile.ui.usecases.DatesActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -21,10 +18,10 @@ class SphFragment : AbstractRecommendationFragment() {
         UseCaseOption(EnumAdviceTask.CURRENT_CASSAVA_YIELD)
     )
 
-    override fun mapTaskToIntent(task: EnumAdviceTask): Intent? = when (task) {
-        EnumAdviceTask.PLANTING_AND_HARVEST -> Intent(requireContext(), DatesActivity::class.java)
-        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> Intent(requireContext(), CassavaMarketActivity::class.java)
-        EnumAdviceTask.CURRENT_CASSAVA_YIELD -> Intent(requireContext(), CassavaYieldActivity::class.java)
+    override fun mapTaskToDestination(task: EnumAdviceTask): Int? = when (task) {
+        EnumAdviceTask.PLANTING_AND_HARVEST -> R.id.datesFragment
+        EnumAdviceTask.CASSAVA_MARKET_OUTLET -> R.id.cassavaMarketFragment
+        EnumAdviceTask.CURRENT_CASSAVA_YIELD -> R.id.cassavaYieldFragment
         else -> null
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/SummaryFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/SummaryFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.activityViewModels
 import com.akilimo.mobile.base.BaseStepFragment
 import com.akilimo.mobile.databinding.FragmentSummaryBinding
 import com.akilimo.mobile.databinding.ItemSummaryRowBinding
+import com.akilimo.mobile.enums.EnumOperationType
 import com.akilimo.mobile.ui.viewmodels.OnboardingViewModel
 import com.google.android.material.card.MaterialCardView
 import kotlinx.coroutines.launch
@@ -67,6 +68,9 @@ class SummaryFragment : BaseStepFragment<FragmentSummaryBinding>() {
             addSection("🚜 Tillage Operations") {
                 user.tillageOperations.forEach {
                     addRow(it.operation.displayLabel, it.method.displayLabel)
+                }
+                user.weedControlMethod?.let {
+                    addRow(EnumOperationType.WEEDING.label(requireContext()), it.label(requireContext()))
                 }
             }
 

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/TillageOperationFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/TillageOperationFragment.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.akilimo.mobile.R
+import com.akilimo.mobile.adapters.BaseValueOptionAdapter
 import com.akilimo.mobile.adapters.ValueOptionAdapter
 import com.akilimo.mobile.base.BaseStepFragment
 import com.akilimo.mobile.databinding.FragmentTillageOperationBinding
@@ -13,9 +14,11 @@ import com.akilimo.mobile.databinding.ItemTillageOperationBinding
 import com.akilimo.mobile.dto.OperationEntry
 import com.akilimo.mobile.dto.OperationMethodOption
 import com.akilimo.mobile.dto.OperationTypeOption
+import com.akilimo.mobile.dto.WeedControlOption
 import com.akilimo.mobile.entities.AkilimoUser
 import com.akilimo.mobile.enums.EnumOperationMethod
 import com.akilimo.mobile.enums.EnumOperationType
+import com.akilimo.mobile.enums.EnumWeedControlMethod
 import com.akilimo.mobile.ui.viewmodels.OnboardingViewModel
 import com.akilimo.mobile.wizard.ValidationError
 import kotlinx.coroutines.launch
@@ -39,6 +42,14 @@ class TillageOperationFragment : BaseStepFragment<FragmentTillageOperationBindin
     private val operationBindings = mutableMapOf<EnumOperationType, ItemTillageOperationBinding>()
     private val selectedEntries = mutableMapOf<EnumOperationType, OperationEntry>()
 
+    private var selectedWeedingMethod: EnumWeedControlMethod? = null
+    private lateinit var weedingRowBinding: ItemTillageOperationBinding
+    private val weedingMethods = listOf(
+        WeedControlOption(EnumWeedControlMethod.MANUAL),
+        WeedControlOption(EnumWeedControlMethod.HERBICIDE),
+        WeedControlOption(EnumWeedControlMethod.HERBICIDE_AND_MANUAL),
+    )
+
     override fun inflateBinding(
         inflater: LayoutInflater,
         container: ViewGroup?
@@ -48,7 +59,6 @@ class TillageOperationFragment : BaseStepFragment<FragmentTillageOperationBindin
         allOperations = listOf(
             OperationTypeOption(EnumOperationType.PLOUGHING.label(requireContext()), EnumOperationType.PLOUGHING),
             OperationTypeOption(EnumOperationType.RIDGING.label(requireContext()), EnumOperationType.RIDGING),
-            OperationTypeOption(EnumOperationType.WEEDING.label(requireContext()), EnumOperationType.WEEDING),
         )
 
         allMethods = listOf(
@@ -64,6 +74,15 @@ class TillageOperationFragment : BaseStepFragment<FragmentTillageOperationBindin
                     setupOperationRow(row, operation, methodAdapter)
                 }
         }
+
+        val weedingAdapter = BaseValueOptionAdapter(
+            requireContext(), weedingMethods,
+            getDisplayText = { it.label(requireContext()) }
+        )
+        weedingRowBinding = ItemTillageOperationBinding.inflate(
+            layoutInflater, binding.containerTillageOperations, true
+        )
+        setupWeedingRow(weedingRowBinding, weedingAdapter)
     }
 
     private fun setupOperationRow(
@@ -89,6 +108,30 @@ class TillageOperationFragment : BaseStepFragment<FragmentTillageOperationBindin
         }
     }
 
+    private fun setupWeedingRow(
+        rowBinding: ItemTillageOperationBinding,
+        adapter: BaseValueOptionAdapter<EnumWeedControlMethod>
+    ) {
+        rowBinding.checkboxOperation.text = EnumOperationType.WEEDING.label(requireContext())
+        rowBinding.checkboxOperation.isChecked = true
+        rowBinding.dropTillageMethod.setAdapter(adapter)
+        rowBinding.dropTillageMethod.isEnabled = true
+
+        rowBinding.checkboxOperation.setOnCheckedChangeListener { _, isChecked ->
+            rowBinding.dropTillageMethod.isEnabled = isChecked
+            if (!isChecked) {
+                selectedWeedingMethod = null
+                rowBinding.dropTillageMethod.setText("", false)
+            }
+        }
+
+        rowBinding.dropTillageMethod.setOnItemClickListener { _, _, position, _ ->
+            val method = weedingMethods.getOrNull(position)?.valueOption ?: return@setOnItemClickListener
+            selectedWeedingMethod = method
+            rowBinding.dropTillageMethod.setText(method.label(requireContext()), false)
+        }
+    }
+
     override fun prefillFromEntity() {
         safeScope.launch {
             val user = onboardingViewModel.getUser(sessionManager.akilimoUser) ?: return@launch
@@ -104,12 +147,18 @@ class TillageOperationFragment : BaseStepFragment<FragmentTillageOperationBindin
                     dropTillageMethod.setText(method.displayLabel, false)
                 }
             }
+
+            user.weedControlMethod?.let { method ->
+                selectedWeedingMethod = method
+                weedingRowBinding.checkboxOperation.isChecked = true
+                weedingRowBinding.dropTillageMethod.isEnabled = true
+                weedingRowBinding.dropTillageMethod.setText(method.label(requireContext()), false)
+            }
         }
     }
 
     override fun verifyStep(): ValidationError? {
-        val missing = allOperations.filter { !selectedEntries.containsKey(it.valueOption) }
-        if (missing.isNotEmpty()) {
+        if (weedingRowBinding.checkboxOperation.isChecked && selectedWeedingMethod == null) {
             return ValidationError(getString(R.string.lbl_select_tillage_method))
         }
 
@@ -117,7 +166,10 @@ class TillageOperationFragment : BaseStepFragment<FragmentTillageOperationBindin
             val user = onboardingViewModel.getUser(sessionManager.akilimoUser)
                 ?: AkilimoUser(userName = sessionManager.akilimoUser)
             onboardingViewModel.saveUser(
-                user.copy(tillageOperations = selectedEntries.values.toList()),
+                user.copy(
+                    tillageOperations = selectedEntries.values.toList(),
+                    weedControlMethod = if (weedingRowBinding.checkboxOperation.isChecked) selectedWeedingMethod else null
+                ),
                 sessionManager.akilimoUser
             )
         }

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/CassavaMarketFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/CassavaMarketFragment.kt
@@ -1,0 +1,193 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.MenuItem
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.akilimo.mobile.R
+import com.akilimo.mobile.adapters.CassavaUnitAdapter
+import com.akilimo.mobile.adapters.StarchFactoryAdapter
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityCassavaMarketBinding
+import com.akilimo.mobile.entities.CassavaMarketPrice
+import com.akilimo.mobile.entities.CassavaUnit
+import com.akilimo.mobile.entities.SelectedCassavaMarket
+import com.akilimo.mobile.enums.EnumUnitOfSale
+import com.akilimo.mobile.ui.components.ToolbarHelper
+import com.akilimo.mobile.ui.dialogs.CassavaPriceSelectionBottomSheet
+import com.akilimo.mobile.ui.viewmodels.CassavaMarketViewModel
+import com.akilimo.mobile.workers.CassavaUnitWorker
+import com.akilimo.mobile.workers.StarchFactoryWorker
+import com.akilimo.mobile.workers.WorkConstants
+import com.akilimo.mobile.workers.WorkerScheduler
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class CassavaMarketFragment : BaseFragment<ActivityCassavaMarketBinding>() {
+
+    private val viewModel: CassavaMarketViewModel by viewModels()
+
+    private lateinit var factoryAdapter: StarchFactoryAdapter
+    private lateinit var cassavaUnitAdapter: CassavaUnitAdapter
+
+    private var isGridLayout = false
+    private var initialChoiceApplied = false
+    private val gridSpanCount by lazy { resources.getInteger(R.integer.grid_span_count_default) }
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityCassavaMarketBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        ToolbarHelper(requireActivity() as androidx.appcompat.app.AppCompatActivity, binding.lytToolbar.toolbar)
+            .showBackButton(true)
+            .setTitle(getString(R.string.lbl_cassava_price))
+            .inflateMenu(R.menu.menu_fertilizers) { item -> onMenuItemClicked(item) }
+            .onNavigationClick { requireActivity().onBackPressedDispatcher.onBackPressed() }
+            .build()
+
+        setupRecyclerViews()
+        setupListeners()
+        observeViewModel()
+        viewModel.loadData(sessionManager.akilimoUser)
+    }
+
+    private fun onMenuItemClicked(item: MenuItem) {
+        if (item.itemId == R.id.action_toggle_layout) {
+            isGridLayout = !isGridLayout
+            binding.rvStarchFactories.layoutManager =
+                if (isGridLayout) GridLayoutManager(requireContext(), gridSpanCount)
+                else LinearLayoutManager(requireContext())
+            factoryAdapter.setLayoutMode(isGridLayout)
+            item.setIcon(if (isGridLayout) R.drawable.ic_list else R.drawable.ic_grid)
+        }
+    }
+
+    private fun setupRecyclerViews() = with(binding) {
+        factoryAdapter = StarchFactoryAdapter()
+        rvStarchFactories.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = factoryAdapter
+            setHasFixedSize(true)
+        }
+
+        cassavaUnitAdapter = CassavaUnitAdapter()
+        rvCassavaUnit.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = cassavaUnitAdapter
+            setHasFixedSize(true)
+        }
+
+        factoryAdapter.onItemClick = { factory -> viewModel.selectFactory(factory) }
+
+        cassavaUnitAdapter.onItemClick = { unit ->
+            safeScope.launch {
+                val userId = viewModel.uiState.value.userId
+                val country = viewModel.uiState.value.userCountry
+                val marketWithDetails = viewModel.selectedRepo.getSelectedByUser(userId)
+                val marketPrice = marketWithDetails?.marketPrice
+                val selectedMarket = marketWithDetails?.selectedCassavaMarket
+                val uos = EnumUnitOfSale.entries.find { it.name.equals(unit.label, ignoreCase = true) }
+                val prices = viewModel.priceRepo.getPricesByCountry(country)
+                val updatedPriceList = prices.map {
+                    val shouldSelect = (it.id == marketPrice?.id) && (selectedMarket?.unitOfSale == uos)
+                    it.copy().apply { isSelected = shouldSelect }
+                }
+                showUnitPriceBottomSheet(unit, selectedMarket, updatedPriceList)
+            }
+        }
+
+        swipeRefreshFactories.setOnRefreshListener {
+            WorkerScheduler.scheduleOneTimeWorker<StarchFactoryWorker>(
+                context = requireContext(),
+                workName = WorkConstants.STARCH_FACTORY_WORK_NAME
+            )
+        }
+        swipeRefreshUnits.setOnRefreshListener {
+            WorkerScheduler.scheduleOneTimeWorker<CassavaUnitWorker>(
+                context = requireContext(),
+                workName = WorkConstants.CASSAVA_UNITS_WORK_NAME
+            )
+        }
+    }
+
+    private fun setupListeners() = with(binding) {
+        rgMarketChoice.setOnCheckedChangeListener { _, checkedId ->
+            when (checkedId) {
+                R.id.rb_sell_to_factory -> {
+                    swipeRefreshFactories.isVisible = true
+                    swipeRefreshUnits.isVisible = false
+                    WorkerScheduler.scheduleOneTimeWorker<StarchFactoryWorker>(
+                        context = requireContext(),
+                        workName = WorkConstants.STARCH_FACTORY_WORK_NAME
+                    )
+                }
+                R.id.rb_sell_to_market -> {
+                    swipeRefreshFactories.isVisible = false
+                    swipeRefreshUnits.isVisible = true
+                    WorkerScheduler.scheduleOneTimeWorker<CassavaUnitWorker>(
+                        context = requireContext(),
+                        workName = WorkConstants.CASSAVA_UNITS_WORK_NAME
+                    )
+                }
+            }
+        }
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    val factories = state.factories.map { f ->
+                        f.copy().apply { isSelected = f.id == state.selectedFactoryId }
+                    }
+                    factoryAdapter.submitList(factories)
+
+                    val units = state.cassavaUnits.map { u ->
+                        u.copy().apply { isSelected = u.id == state.selectedUnitId }
+                    }
+                    cassavaUnitAdapter.submitList(units)
+
+                    binding.swipeRefreshFactories.isRefreshing = state.factoriesRefreshing
+                    binding.swipeRefreshUnits.isRefreshing = state.unitsRefreshing
+
+                    if (!initialChoiceApplied) {
+                        when (state.initialMarketChoice) {
+                            CassavaMarketViewModel.MarketChoice.FACTORY -> {
+                                binding.rgMarketChoice.check(R.id.rb_sell_to_factory)
+                                initialChoiceApplied = true
+                            }
+                            CassavaMarketViewModel.MarketChoice.MARKET -> {
+                                binding.rgMarketChoice.check(R.id.rb_sell_to_market)
+                                initialChoiceApplied = true
+                            }
+                            CassavaMarketViewModel.MarketChoice.NONE -> Unit
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showUnitPriceBottomSheet(
+        unit: CassavaUnit,
+        selectedMarket: SelectedCassavaMarket?,
+        prices: List<CassavaMarketPrice>
+    ) {
+        CassavaPriceSelectionBottomSheet(
+            unit = unit,
+            selectedMarket = selectedMarket,
+            prices = prices,
+            onPriceSelected = { selectedPrice, uos ->
+                viewModel.saveSelectedPrice(sessionManager.akilimoUser, unit, uos, selectedPrice)
+            }
+        ).show(childFragmentManager, "CassavaPriceSelectionBottomSheet")
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/CassavaMarketFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/CassavaMarketFragment.kt
@@ -20,6 +20,7 @@ import com.akilimo.mobile.entities.CassavaMarketPrice
 import com.akilimo.mobile.entities.CassavaUnit
 import com.akilimo.mobile.entities.SelectedCassavaMarket
 import com.akilimo.mobile.enums.EnumUnitOfSale
+import androidx.navigation.fragment.findNavController
 import com.akilimo.mobile.ui.components.ToolbarHelper
 import com.akilimo.mobile.ui.dialogs.CassavaPriceSelectionBottomSheet
 import com.akilimo.mobile.ui.viewmodels.CassavaMarketViewModel
@@ -50,7 +51,7 @@ class CassavaMarketFragment : BaseFragment<ActivityCassavaMarketBinding>() {
             .showBackButton(true)
             .setTitle(getString(R.string.lbl_cassava_price))
             .inflateMenu(R.menu.menu_fertilizers) { item -> onMenuItemClicked(item) }
-            .onNavigationClick { requireActivity().onBackPressedDispatcher.onBackPressed() }
+            .onNavigationClick { findNavController().popBackStack() }
             .build()
 
         setupRecyclerViews()

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/CassavaYieldFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/CassavaYieldFragment.kt
@@ -1,0 +1,141 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.GridLayoutManager
+import com.akilimo.mobile.adapters.CassavaYieldAdapter
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityCassavaYieldBinding
+import com.akilimo.mobile.entities.CassavaYield
+import com.akilimo.mobile.enums.EnumAdvice
+import com.akilimo.mobile.enums.EnumAreaUnit
+import com.akilimo.mobile.ui.viewmodels.CassavaYieldViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.akilimo.mobile.R
+
+@AndroidEntryPoint
+class CassavaYieldFragment : BaseFragment<ActivityCassavaYieldBinding>() {
+
+    private val yieldImages = arrayOf(
+        R.drawable.yield_less_than_7point5,
+        R.drawable.yield_7point5_to_15,
+        R.drawable.yield_15_to_22point5,
+        R.drawable.yield_22_to_30,
+        R.drawable.yield_more_than_30,
+    )
+
+    private val viewModel: CassavaYieldViewModel by viewModels()
+    private lateinit var cassavaYieldAdapter: CassavaYieldAdapter
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityCassavaYieldBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        cassavaYieldAdapter = CassavaYieldAdapter().apply {
+            onItemClick = { cassavaYield ->
+                viewModel.selectYield(sessionManager.akilimoUser, cassavaYield)
+            }
+        }
+
+        binding.rvCassavaYield.apply {
+            layoutManager = GridLayoutManager(requireContext(), 2)
+            adapter = cassavaYieldAdapter
+            setHasFixedSize(true)
+        }
+
+        observeViewModel()
+        viewModel.loadData(sessionManager.akilimoUser)
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    val tonnage = when (state.areaUnit) {
+                        EnumAreaUnit.ARE -> getString(R.string.lbl_are_yield)
+                        EnumAreaUnit.HA -> getString(R.string.lbl_ha_yield)
+                        else -> getString(R.string.lbl_acre_yield)
+                    }
+                    binding.rootYieldTitle.text = if (state.useCase == EnumAdvice.FERTILIZER_RECOMMENDATIONS) {
+                        getString(R.string.lbl_typical_yield_question_fr, tonnage)
+                    } else {
+                        getString(R.string.lbl_typical_yield_question, tonnage)
+                    }
+
+                    state.seedRequest?.let { areaUnit ->
+                        viewModel.seedYields(seedDefaultYields(areaUnit))
+                    }
+
+                    if (state.yields.isNotEmpty()) {
+                        val enriched = state.yields.map { y ->
+                            y.copyWithSelection(y.id == state.selectedYieldId)
+                        }
+                        cassavaYieldAdapter.submitList(enriched)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun seedDefaultYields(areaUnit: EnumAreaUnit): List<CassavaYield> {
+        fun unit(
+            @StringRes a: Int, @StringRes b: Int, @StringRes c: Int,
+            @StringRes d: Int, @StringRes e: Int
+        ) = intArrayOf(a, b, c, d, e)
+
+        val amountLabelResByUnit: Map<EnumAreaUnit, IntArray> = mapOf(
+            EnumAreaUnit.ACRE to unit(
+                R.string.yield_less_than_3_tonnes_per_acre, R.string.yield_3_to_6_tonnes_per_acre,
+                R.string.yield_6_to_9_tonnes_per_acre, R.string.yield_9_to_12_tonnes_per_acre,
+                R.string.yield_more_than_12_tonnes_per_acre
+            ),
+            EnumAreaUnit.HA to unit(
+                R.string.yield_less_than_3_tonnes_per_hectare, R.string.yield_3_to_6_tonnes_per_hectare,
+                R.string.yield_6_to_9_tonnes_per_hectare, R.string.yield_9_to_12_tonnes_per_hectare,
+                R.string.yield_more_than_12_tonnes_per_hectare
+            ),
+            EnumAreaUnit.ARE to unit(
+                R.string.yield_less_than_3_tonnes_per_are, R.string.yield_3_to_6_tonnes_per_are,
+                R.string.yield_6_to_9_tonnes_per_are, R.string.yield_9_to_12_tonnes_per_are,
+                R.string.yield_more_than_12_tonnes_per_are
+            ),
+            EnumAreaUnit.M2 to unit(
+                R.string.yield_less_than_3_tonnes_per_meter, R.string.yield_3_to_6_tonnes_per_meter,
+                R.string.yield_6_to_9_tonnes_per_meter, R.string.yield_9_to_12_tonnes_per_meter,
+                R.string.yield_more_than_12_tonnes_per_meter
+            )
+        )
+
+        data class YieldDef(
+            @param:DrawableRes val imageId: Int,
+            @param:StringRes val labelRes: Int,
+            val amountValue: Double,
+            @param:StringRes val descRes: Int
+        )
+
+        val yieldDefs = listOf(
+            YieldDef(yieldImages[0], R.string.fcy_lower, 3.75, R.string.lbl_low_yield),
+            YieldDef(yieldImages[1], R.string.fcy_about_the_same, 11.25, R.string.lbl_normal_yield),
+            YieldDef(yieldImages[2], R.string.fcy_somewhat_higher, 18.75, R.string.lbl_high_yield),
+            YieldDef(yieldImages[3], R.string.fcy_2_3_times_higher, 26.25, R.string.lbl_very_high_yield),
+            YieldDef(yieldImages[4], R.string.fcy_more_than_3_times_higher, 33.75, R.string.lbl_very_high_yield)
+        )
+
+        val amountRes = amountLabelResByUnit[areaUnit] ?: amountLabelResByUnit[EnumAreaUnit.ACRE]!!
+        val resolvedLabels = amountRes.map { getString(it) }
+
+        return yieldDefs.mapIndexed { index, def ->
+            CassavaYield.create(
+                def.amountValue, getString(def.labelRes), def.imageId, getString(def.descRes)
+            ).also { it.amountLabel = resolvedLabels[index] }
+        }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/DatesFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/DatesFragment.kt
@@ -1,0 +1,239 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.os.bundleOf
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import com.akilimo.mobile.R
+import com.akilimo.mobile.adapters.ValueOptionAdapter
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityAlternativePlantingScheduleBinding
+import com.akilimo.mobile.dto.PlantingFlexOption
+import com.akilimo.mobile.entities.AdviceCompletionDto
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumStepStatus
+import com.akilimo.mobile.ui.components.CustomDatePicker
+import com.akilimo.mobile.ui.viewmodels.DatesViewModel
+import com.akilimo.mobile.utils.DateHelper
+import com.akilimo.mobile.utils.DateHelper.olderThanCurrent
+import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.textfield.MaterialAutoCompleteTextView
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+
+@AndroidEntryPoint
+class DatesFragment : BaseFragment<ActivityAlternativePlantingScheduleBinding>() {
+
+    private val viewModel: DatesViewModel by viewModels()
+
+    private var plantingDate: LocalDate? = null
+    private var harvestDate: LocalDate? = null
+    private var alternativeDate = false
+    private var alreadyPlanted = false
+    private var flexOptions: List<PlantingFlexOption> = emptyList()
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityAlternativePlantingScheduleBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        flexOptions = listOf(
+            PlantingFlexOption(getString(R.string.lbl_no_flexibility), 0),
+            PlantingFlexOption(getString(R.string.lbl_one_month_window), 1),
+            PlantingFlexOption(getString(R.string.lbl_two_month_window), 2),
+        )
+
+        setupUI()
+        observeViewModel()
+        binding.fabSave.hide()
+        viewModel.loadData(sessionManager.akilimoUser)
+    }
+
+    private fun setupUI() = with(binding.lytPlantingSectionActivity) {
+        binding.switchAlternativePlanting.setOnCheckedChangeListener { _, isChecked ->
+            alternativeDate = isChecked
+            root.visibility = if (isChecked) View.VISIBLE else View.GONE
+            toggleFab()
+        }
+
+        binding.fabSave.setOnClickListener {
+            savePlantingSchedule()
+            toggleFab()
+        }
+
+        setupFlexSpinner(dropPlantingFlex)
+        setupFlexSpinner(dropHarvestFlex)
+
+        switchFlexibleDates.setOnCheckedChangeListener { _, isChecked ->
+            cardFlexOptions.visibility = if (isChecked) View.VISIBLE else View.GONE
+        }
+
+        inputPlantingDate.setOnClickListener { showPlantingDatePicker() }
+        inputHarvestDate.setOnClickListener { showHarvestDatePicker() }
+        inputPlantingDate.addTextChangedListener { toggleFab() }
+        inputHarvestDate.addTextChangedListener { toggleFab() }
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    if (state.saved) {
+                        val completion = AdviceCompletionDto(
+                            EnumAdviceTask.PLANTING_AND_HARVEST, EnumStepStatus.COMPLETED
+                        )
+                        parentFragmentManager.setFragmentResult(
+                            UseCaseResults.ADVICE_COMPLETION,
+                            bundleOf(UseCaseResults.ADVICE_COMPLETION_DTO to completion)
+                        )
+                        viewModel.onSaveHandled()
+                        findNavController().popBackStack()
+                        return@collect
+                    }
+
+                    state.user ?: return@collect
+                    populateUserData(state)
+                }
+            }
+        }
+    }
+
+    private fun populateUserData(state: DatesViewModel.UiState) =
+        with(binding.lytPlantingSectionActivity) {
+            val user = state.user ?: return@with
+            binding.switchAlternativePlanting.isChecked =
+                user.providedAlterNativeDate.also { alternativeDate = it }
+            plantingDate =
+                user.plantingDate?.also { inputPlantingDate.setText(DateHelper.formatToString(it)) }
+            harvestDate =
+                user.harvestDate?.also { inputHarvestDate.setText(DateHelper.formatToString(it)) }
+            alreadyPlanted = olderThanCurrent(plantingDate)
+
+            if (user.plantingFlex > 0 || user.harvestFlex > 0) {
+                switchFlexibleDates.isChecked = true
+                layoutFlexOptions.visibility = View.VISIBLE
+            }
+
+            dropPlantingFlex.setText(
+                flexOptions.find { it.valueOption == user.plantingFlex }?.displayLabel.orEmpty(), false
+            )
+            dropHarvestFlex.setText(
+                flexOptions.find { it.valueOption == user.harvestFlex }?.displayLabel.orEmpty(), false
+            )
+        }
+
+    private fun setupFlexSpinner(spinnerInput: MaterialAutoCompleteTextView) {
+        val adapter = ValueOptionAdapter(requireContext(), flexOptions)
+        spinnerInput.setAdapter(adapter)
+        spinnerInput.setOnItemClickListener { _, _, position, _ ->
+            val selected = adapter.getItem(position) ?: return@setOnItemClickListener
+            if (alreadyPlanted && spinnerInput == binding.lytPlantingSectionActivity.dropPlantingFlex) {
+                val defaultOption = flexOptions.first { it.valueOption == 0L }
+                spinnerInput.setText(defaultOption.displayLabel, false)
+                val snackBar = Snackbar.make(
+                    binding.root, getString(R.string.lbl_already_planted_text), Snackbar.LENGTH_INDEFINITE
+                )
+                snackBar.setAction(getString(R.string.lbl_ok)) { snackBar.dismiss() }
+                snackBar.show()
+            } else {
+                spinnerInput.setText(selected.displayLabel, false)
+            }
+            toggleFab()
+        }
+    }
+
+    private fun showPlantingDatePicker() {
+        val selectedFlexLabel = binding.lytPlantingSectionActivity.dropPlantingFlex.text.toString()
+        val flex = flexOptions.find { it.displayLabel == selectedFlexLabel }?.valueOption ?: 0
+        val minDate = LocalDate.now().minusMonths(4 + flex)
+        val maxDate = LocalDate.now().plusMonths(12 + flex)
+
+        CustomDatePicker(
+            context = requireContext(),
+            fragmentManager = childFragmentManager,
+            title = getString(R.string.lbl_planting_date),
+            minDate = minDate,
+            maxDate = maxDate,
+            initialDate = plantingDate
+        ) { selected ->
+            plantingDate = selected
+            alreadyPlanted = olderThanCurrent(selected)
+            binding.lytPlantingSectionActivity.apply {
+                inputPlantingDate.setText(DateHelper.formatToString(selected))
+                dropPlantingFlex.isEnabled = !alreadyPlanted
+                if (alreadyPlanted) {
+                    dropPlantingFlex.setText(flexOptions.first { it.valueOption == 0L }.displayLabel, false)
+                }
+                inputHarvestDate.text = null
+                harvestDate = null
+            }
+            toggleFab()
+        }.show()
+    }
+
+    private fun showHarvestDatePicker() {
+        val planting = plantingDate ?: run {
+            Toast.makeText(requireContext(), getString(R.string.lbl_planting_date_prompt), Toast.LENGTH_SHORT).show()
+            return
+        }
+        val selectedFlexLabel = binding.lytPlantingSectionActivity.dropHarvestFlex.text.toString()
+        val flex = flexOptions.find { it.displayLabel == selectedFlexLabel }?.valueOption ?: 0
+        val minDate = planting.plusMonths(8 - flex)
+        val maxDate = planting.plusMonths(16 + flex)
+
+        CustomDatePicker(
+            context = requireContext(),
+            fragmentManager = childFragmentManager,
+            title = getString(R.string.lbl_harvesting_date),
+            minDate = minDate,
+            maxDate = maxDate,
+            initialDate = harvestDate
+        ) { selected ->
+            harvestDate = selected
+            binding.lytPlantingSectionActivity.inputHarvestDate.setText(DateHelper.formatToString(selected))
+            toggleFab()
+        }.show()
+    }
+
+    private fun savePlantingSchedule() = with(binding.lytPlantingSectionActivity) {
+        lytPlantingDate.error = null
+        lytHarvestDate.error = null
+        if (plantingDate == null) { lytPlantingDate.error = getString(R.string.lbl_planting_date_prompt); return@with }
+        if (harvestDate == null) { lytHarvestDate.error = getString(R.string.lbl_harvest_date_prompt); return@with }
+        val plantingFlex = flexOptions.find { it.displayLabel == dropPlantingFlex.text.toString() }?.valueOption ?: 0
+        val harvestFlex = flexOptions.find { it.displayLabel == dropHarvestFlex.text.toString() }?.valueOption ?: 0
+        viewModel.saveSchedule(
+            userName = sessionManager.akilimoUser,
+            plantingDate = plantingDate!!,
+            harvestDate = harvestDate!!,
+            plantingFlex = plantingFlex,
+            harvestFlex = harvestFlex,
+            alternativeDate = alternativeDate
+        )
+    }
+
+    private fun hasFormChanged(): Boolean {
+        val state = viewModel.uiState.value
+        val user = state.user ?: return false
+        return with(binding.lytPlantingSectionActivity) {
+            val plantingFlexLabel = flexOptions.find { it.valueOption == user.plantingFlex }?.displayLabel.orEmpty()
+            val harvestFlexLabel = flexOptions.find { it.valueOption == user.harvestFlex }?.displayLabel.orEmpty()
+            plantingDate != user.plantingDate || harvestDate != user.harvestDate ||
+                    alternativeDate != user.providedAlterNativeDate ||
+                    dropPlantingFlex.text.toString() != plantingFlexLabel ||
+                    dropHarvestFlex.text.toString() != harvestFlexLabel
+        }
+    }
+
+    private fun toggleFab() {
+        if (hasFormChanged()) binding.fabSave.show() else binding.fabSave.hide()
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/FertilizersFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/FertilizersFragment.kt
@@ -1,0 +1,26 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.akilimo.mobile.databinding.ActivityFertilizersBinding
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.ui.usecases.fertilizer.BaseFertilizerFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class FertilizersFragment : BaseFertilizerFragment<ActivityFertilizersBinding>() {
+
+    override val adviseTask = EnumAdviceTask.AVAILABLE_FERTILIZERS
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityFertilizersBinding.inflate(inflater, container, false)
+
+    override fun getToolbar() = binding.lytToolbar.toolbar
+    override fun getRecyclerView(): RecyclerView = binding.fertilizersList
+    override fun getRootView(): View = binding.root
+    override fun getEmptyStateView(): View = binding.emptyState
+    override fun getSyncIndicator(): View = binding.syncIndicator
+    override fun getRefreshFab(): View = binding.fabRefresh
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/GetRecommendationFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/GetRecommendationFragment.kt
@@ -1,0 +1,193 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.akilimo.mobile.R
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityGetRecommendationBinding
+import com.akilimo.mobile.databinding.BottomSheetFeedbackBinding
+import com.akilimo.mobile.enums.EnumUseCase
+import com.akilimo.mobile.ui.viewmodels.GetRecommendationViewModel
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.button.MaterialButton
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class GetRecommendationFragment : BaseFragment<ActivityGetRecommendationBinding>() {
+
+    companion object {
+        const val ARG_USE_CASE = "arg_use_case"
+    }
+
+    private lateinit var useCase: EnumUseCase
+    private val viewModel: GetRecommendationViewModel by viewModels()
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityGetRecommendationBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        @Suppress("DEPRECATION")
+        useCase = arguments?.getParcelable(ARG_USE_CASE)
+            ?: run { showError(getString(R.string.error_no_use_case)); return }
+
+        setupClickListeners()
+        observeViewModel()
+        viewModel.fetchRecommendation(
+            useCase = useCase,
+            noRecsLabel = getString(R.string.lbl_no_recommendations_prompt),
+            errorLabel = getString(R.string.error_fetch_recommendation)
+        )
+    }
+
+    private fun setupClickListeners() {
+        binding.btnRetry.setOnClickListener {
+            viewModel.fetchRecommendation(
+                useCase = useCase,
+                noRecsLabel = getString(R.string.lbl_no_recommendations_prompt),
+                errorLabel = getString(R.string.error_fetch_recommendation)
+            )
+        }
+        binding.fabFeedback.setOnClickListener { showFeedbackBottomSheet() }
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    when (state) {
+                        is GetRecommendationViewModel.UiState.Loading -> showLoading()
+                        is GetRecommendationViewModel.UiState.Success -> {
+                            val title = when (state.title) {
+                                "FR" -> getString(R.string.lbl_fertilizer_rec)
+                                "IC" -> getString(R.string.lbl_intercrop_rec)
+                                "PP" -> getString(R.string.lbl_planting_practices_rec)
+                                "SP" -> getString(R.string.lbl_scheduled_planting_rec)
+                                else -> getString(R.string.lbl_no_recommendations_prompt)
+                            }
+                            showRecommendation(title, state.description)
+                        }
+                        is GetRecommendationViewModel.UiState.Error -> showError(state.message)
+                        is GetRecommendationViewModel.UiState.Idle -> Unit
+                    }
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.feedbackResult.collect { success ->
+                    val msg = if (success) getString(R.string.feedback_success)
+                    else getString(R.string.feedback_error)
+                    Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    private fun showLoading() = with(binding) {
+        loadingIndicator.visibility = View.VISIBLE
+        recommendationCard.visibility = View.GONE
+        errorState.visibility = View.GONE
+        fabFeedback.visibility = View.GONE
+    }
+
+    private fun showRecommendation(title: String, description: String) = with(binding) {
+        loadingIndicator.visibility = View.GONE
+        errorState.visibility = View.GONE
+        recommendationCard.visibility = View.VISIBLE
+        fabFeedback.visibility = View.VISIBLE
+        recommendationTitle.text = title
+        recommendationDescription.text = description
+    }
+
+    private fun showError(error: String) = with(binding) {
+        loadingIndicator.visibility = View.GONE
+        recommendationCard.visibility = View.GONE
+        errorState.visibility = View.VISIBLE
+        emptyStateSubtitle.text = error
+        fabFeedback.visibility = View.GONE
+    }
+
+    private fun showFeedbackBottomSheet() {
+        val bottomSheetDialog = BottomSheetDialog(requireContext())
+        val sheetBinding = BottomSheetFeedbackBinding.inflate(layoutInflater)
+        bottomSheetDialog.setContentView(sheetBinding.root)
+
+        var selectedRating: Int? = null
+        var selectedNps: Int? = null
+
+        val ratingButtons = listOf(
+            sheetBinding.btnRating1 to 1, sheetBinding.btnRating2 to 2,
+            sheetBinding.btnRating3 to 3, sheetBinding.btnRating4 to 4,
+            sheetBinding.btnRating5 to 5
+        )
+        ratingButtons.forEach { (button, rating) ->
+            button.setOnClickListener {
+                selectedRating = rating
+                updateButtonSelection(ratingButtons, button)
+                sheetBinding.selectedRating.apply {
+                    visibility = View.VISIBLE
+                    text = getRatingLabel(rating)
+                }
+                updateSubmitButton(sheetBinding, selectedRating, selectedNps)
+            }
+        }
+
+        val npsButtons = listOf(
+            sheetBinding.btnNps0 to 0, sheetBinding.btnNps1 to 1, sheetBinding.btnNps2 to 2,
+            sheetBinding.btnNps3 to 3, sheetBinding.btnNps4 to 4, sheetBinding.btnNps5 to 5,
+            sheetBinding.btnNps6 to 6, sheetBinding.btnNps7 to 7, sheetBinding.btnNps8 to 8,
+            sheetBinding.btnNps9 to 9, sheetBinding.btnNps10 to 10
+        )
+        npsButtons.forEach { (button, score) ->
+            button.setOnClickListener {
+                selectedNps = score
+                updateButtonSelection(npsButtons, button)
+                sheetBinding.selectedNps.apply {
+                    visibility = View.VISIBLE
+                    text = getNpsLabel(score)
+                }
+                updateSubmitButton(sheetBinding, selectedRating, selectedNps)
+            }
+        }
+
+        sheetBinding.btnSubmitFeedback.setOnClickListener {
+            val rating = selectedRating
+            val nps = selectedNps
+            if (rating != null && nps != null) {
+                bottomSheetDialog.dismiss()
+                viewModel.submitFeedback(useCase, rating, nps)
+            }
+        }
+
+        bottomSheetDialog.show()
+    }
+
+    private fun getRatingLabel(rating: Int) = when (rating) {
+        1 -> getString(R.string.feedback_very_poor); 2 -> getString(R.string.feedback_poor)
+        3 -> getString(R.string.feedback_okay); 4 -> getString(R.string.feedback_good)
+        5 -> getString(R.string.feedback_excellent); else -> ""
+    }
+
+    private fun getNpsLabel(score: Int) = when {
+        score <= 6 -> getString(R.string.feedback_nps_low)
+        score <= 8 -> getString(R.string.feedback_nps_medium)
+        else -> getString(R.string.feedback_nps_high)
+    }
+
+    private fun updateButtonSelection(buttons: List<Pair<MaterialButton, Int>>, selected: MaterialButton) {
+        buttons.forEach { (button, _) -> button.isSelected = button == selected }
+    }
+
+    private fun updateSubmitButton(binding: BottomSheetFeedbackBinding, rating: Int?, nps: Int?) {
+        binding.btnSubmitFeedback.isEnabled = rating != null && nps != null
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/InterCropFertilizersFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/InterCropFertilizersFragment.kt
@@ -1,0 +1,28 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.akilimo.mobile.databinding.ActivityFertilizersBinding
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumFertilizerFlow
+import com.akilimo.mobile.ui.usecases.fertilizer.BaseFertilizerFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class InterCropFertilizersFragment : BaseFertilizerFragment<ActivityFertilizersBinding>() {
+
+    override val adviseTask = EnumAdviceTask.AVAILABLE_FERTILIZERS_CIM
+    override val fertilizerFlow = EnumFertilizerFlow.CIM
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityFertilizersBinding.inflate(inflater, container, false)
+
+    override fun getToolbar() = binding.lytToolbar.toolbar
+    override fun getRecyclerView(): RecyclerView = binding.fertilizersList
+    override fun getRootView(): View = binding.root
+    override fun getEmptyStateView(): View = binding.emptyState
+    override fun getSyncIndicator(): View = binding.syncIndicator
+    override fun getRefreshFab(): View = binding.fabRefresh
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/InvestmentAmountFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/InvestmentAmountFragment.kt
@@ -1,0 +1,62 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.akilimo.mobile.adapters.InvestmentAmountAdapter
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityInvestmentAmountBinding
+import com.akilimo.mobile.ui.viewmodels.InvestmentAmountViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class InvestmentAmountFragment : BaseFragment<ActivityInvestmentAmountBinding>() {
+
+    private val viewModel: InvestmentAmountViewModel by viewModels()
+    private lateinit var adapter: InvestmentAmountAdapter
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityInvestmentAmountBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        adapter = InvestmentAmountAdapter { selected, amount ->
+            viewModel.saveInvestment(sessionManager.akilimoUser, selected, amount)
+        }
+
+        binding.rvInvestments.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = this@InvestmentAmountFragment.adapter
+            setHasFixedSize(true)
+        }
+
+        observeViewModel()
+        viewModel.loadData(sessionManager.akilimoUser)
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    adapter.submitList(state.investments)
+                    binding.rvInvestments.visibility =
+                        if (state.investments.isEmpty()) View.GONE else View.VISIBLE
+
+                    state.selectedInvestment?.let { selected ->
+                        adapter.updateSelection(
+                            investment = selected,
+                            enumAreaUnit = state.enumAreaUnit,
+                            farmSize = state.farmSize
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/MaizeMarketFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/MaizeMarketFragment.kt
@@ -1,0 +1,101 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.akilimo.mobile.R
+import com.akilimo.mobile.base.AbstractProduceMarketFragment
+import com.akilimo.mobile.databinding.ActivityMaizeMarketBinding
+import com.akilimo.mobile.entities.ProduceMarket
+import com.akilimo.mobile.enums.EnumMarketType
+import com.akilimo.mobile.enums.EnumProduceType
+import com.akilimo.mobile.enums.EnumUnitOfSale
+import com.akilimo.mobile.ui.components.ProduceMarketViews
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class MaizeMarketFragment : AbstractProduceMarketFragment<ActivityMaizeMarketBinding>(
+    marketType = EnumMarketType.MAIZE_MARKET,
+    titleRes = R.string.lbl_maize_market
+) {
+
+    override val views: ProduceMarketViews
+        get() = ProduceMarketViews.Binding(
+            unitLabel = binding.unitLabel,
+            unitInputLayout = binding.unitInputLayout,
+            unitSpinner = binding.unitSpinner,
+            inputPrice = binding.inputPrice,
+            priceInputLayout = binding.priceInputLayout,
+            fabSave = binding.lytFab.fabSave,
+            marketHintCard = binding.marketHintCard,
+            marketHintText = binding.marketHintText,
+            toolbar = binding.lytToolbar.toolbar
+        )
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityMaizeMarketBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        super.onBindingReady(savedInstanceState)
+
+        // Apply defaults when no saved entry exists
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    if (state.userId != 0 && state.lastEntry == null) {
+                        binding.produceTypeGroup.check(binding.freshCobsOption.id)
+                        updateUnits { it == EnumUnitOfSale.FRESH_COB }
+                        binding.unitSpinner.setText(
+                            EnumUnitOfSale.FRESH_COB.unitOfSale(requireContext()),
+                            false
+                        )
+                        binding.priceInputLayout.hint =
+                            getString(R.string.lbl_price_per_cob_in_currency_unit)
+                                .replace("{currency}", currencyCode)
+                        validateForm()
+                    }
+                }
+            }
+        }
+    }
+
+    override fun resolveProduceType(): EnumProduceType = when {
+        binding.freshCobsOption.isChecked -> EnumProduceType.MAIZE_FRESH_COB
+        binding.dryGrainOption.isChecked -> EnumProduceType.MAIZE_GRAIN
+        else -> EnumProduceType.UNKNOWN
+    }
+
+    override fun setupProduceTypeSelection() {
+        binding.produceTypeGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            if (!isChecked) return@addOnButtonCheckedListener
+            views.unitSpinner.setText(null, false)
+            views.inputPrice.setText(null)
+
+            when (checkedId) {
+                binding.freshCobsOption.id -> {
+                    updateUnits { it == EnumUnitOfSale.FRESH_COB }
+                    views.priceInputLayout.hint =
+                        getString(R.string.lbl_price_per_cob_in_currency_unit)
+                            .replace("{currency}", currencyCode)
+                }
+                binding.dryGrainOption.id -> {
+                    updateUnits { it.isUniversal }
+                    views.priceInputLayout.hint = getString(R.string.lbl_price_per_kg_bag)
+                }
+            }
+            validateForm()
+        }
+    }
+
+    override fun onEntryPrefilled(entry: ProduceMarket) {
+        when (entry.produceType) {
+            EnumProduceType.MAIZE_FRESH_COB -> binding.produceTypeGroup.check(binding.freshCobsOption.id)
+            EnumProduceType.MAIZE_GRAIN -> binding.produceTypeGroup.check(binding.dryGrainOption.id)
+            else -> Unit
+        }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/MaizePerformanceFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/MaizePerformanceFragment.kt
@@ -1,0 +1,58 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.GridLayoutManager
+import com.akilimo.mobile.adapters.MaizePerformanceAdapter
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityMaizePerformanceBinding
+import com.akilimo.mobile.ui.viewmodels.MaizePerformanceViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class MaizePerformanceFragment : BaseFragment<ActivityMaizePerformanceBinding>() {
+
+    private val viewModel: MaizePerformanceViewModel by viewModels()
+
+    private lateinit var maizePerformanceAdapter: MaizePerformanceAdapter
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityMaizePerformanceBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        binding.toolbarLayout.toolbar.setNavigationOnClickListener {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+        }
+
+        maizePerformanceAdapter = MaizePerformanceAdapter().apply {
+            onItemClick = { selected ->
+                viewModel.saveSelection(sessionManager.akilimoUser, selected)
+            }
+        }
+
+        binding.rvMaizePerformance.apply {
+            layoutManager = GridLayoutManager(requireContext(), 2)
+            adapter = maizePerformanceAdapter
+            setHasFixedSize(true)
+        }
+
+        observeViewModel()
+        viewModel.loadOptions(sessionManager.akilimoUser)
+    }
+
+    private fun observeViewModel() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    maizePerformanceAdapter.submitList(state.options)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/MaizePerformanceFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/MaizePerformanceFragment.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.akilimo.mobile.adapters.MaizePerformanceAdapter
 import com.akilimo.mobile.base.BaseFragment
@@ -27,7 +28,7 @@ class MaizePerformanceFragment : BaseFragment<ActivityMaizePerformanceBinding>()
 
     override fun onBindingReady(savedInstanceState: Bundle?) {
         binding.toolbarLayout.toolbar.setNavigationOnClickListener {
-            requireActivity().onBackPressedDispatcher.onBackPressed()
+            findNavController().popBackStack()
         }
 
         maizePerformanceAdapter = MaizePerformanceAdapter().apply {

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/ManualTillageCostFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/ManualTillageCostFragment.kt
@@ -1,0 +1,95 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import com.akilimo.mobile.R
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityManualTillageCostBinding
+import com.akilimo.mobile.entities.AdviceCompletionDto
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumStepStatus
+import com.akilimo.mobile.ui.viewmodels.ManualTillageCostViewModel
+import com.akilimo.mobile.utils.StringHelper
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class ManualTillageCostFragment : BaseFragment<ActivityManualTillageCostBinding>() {
+
+    private val viewModel: ManualTillageCostViewModel by viewModels()
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityManualTillageCostBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        binding.apply {
+            lytFabButton.fabSave.setOnClickListener {
+                viewModel.saveCosts(
+                    etRidingCost.text?.toString()?.toDoubleOrNull(),
+                    etPloughingCost.text?.toString()?.toDoubleOrNull()
+                )
+            }
+            etPloughingCost.addTextChangedListener { toggleFab() }
+            etRidingCost.addTextChangedListener { toggleFab() }
+            lytFabButton.fabSave.hide()
+        }
+
+        observeViewModel()
+        viewModel.loadData(sessionManager.akilimoUser)
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    if (state.saved) {
+                        val completion = AdviceCompletionDto(EnumAdviceTask.MANUAL_TILLAGE_COST, EnumStepStatus.COMPLETED)
+                        parentFragmentManager.setFragmentResult(
+                            UseCaseResults.ADVICE_COMPLETION,
+                            bundleOf(UseCaseResults.ADVICE_COMPLETION_DTO to completion)
+                        )
+                        viewModel.onSaveHandled()
+                        findNavController().popBackStack()
+                        return@collect
+                    }
+
+                    if (state.userId == 0) return@collect
+
+                    val sizeUnitLabel = state.enumAreaUnit.label(requireContext()).orEmpty()
+                    binding.apply {
+                        tvManualPlough.text = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_tillage_cost, state.farmSize, sizeUnitLabel) } }
+                        tilPloughingCost.hint = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_tillage_cost_hint, state.farmSize, sizeUnitLabel) } }
+                        tvManualRidge.text = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_ridge_cost, state.farmSize, sizeUnitLabel) } }
+                        tilRidgingCost.hint = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_ridge_cost_hint, state.farmSize, sizeUnitLabel) } }
+                        if (state.manualRidgeCost != null && etRidingCost.text.isNullOrEmpty()) etRidingCost.setText(state.manualRidgeCost.toString())
+                        if (state.manualPloughCost != null && etPloughingCost.text.isNullOrEmpty()) etPloughingCost.setText(state.manualPloughCost.toString())
+                    }
+                    toggleFab()
+                }
+            }
+        }
+    }
+
+    private fun hasFormChanged(): Boolean {
+        val state = viewModel.uiState.value
+        if (state.userId == 0) return false
+        fun parse(text: CharSequence?) = text?.toString()?.toDoubleOrNull()?.takeIf { it >= 0 }
+        val plough = parse(binding.etPloughingCost.text)
+        val ridge = parse(binding.etRidingCost.text)
+        return (plough != null && plough != (state.manualPloughCost ?: 0.0)) ||
+               (ridge != null && ridge != (state.manualRidgeCost ?: 0.0))
+    }
+
+    private fun toggleFab() {
+        val show = viewModel.uiState.value.let { it.userId != 0 && (it.manualPloughCost == null || hasFormChanged()) }
+        binding.lytFabButton.fabSave.apply { if (show) show() else hide() }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/SweetPotatoInterCropFertilizersFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/SweetPotatoInterCropFertilizersFragment.kt
@@ -1,0 +1,28 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.akilimo.mobile.databinding.ActivityFertilizersBinding
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumFertilizerFlow
+import com.akilimo.mobile.ui.usecases.fertilizer.BaseFertilizerFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SweetPotatoInterCropFertilizersFragment : BaseFertilizerFragment<ActivityFertilizersBinding>() {
+
+    override val adviseTask = EnumAdviceTask.AVAILABLE_FERTILIZERS_CIS
+    override val fertilizerFlow = EnumFertilizerFlow.CIS
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityFertilizersBinding.inflate(inflater, container, false)
+
+    override fun getToolbar() = binding.lytToolbar.toolbar
+    override fun getRecyclerView(): RecyclerView = binding.fertilizersList
+    override fun getRootView(): View = binding.root
+    override fun getEmptyStateView(): View = binding.emptyState
+    override fun getSyncIndicator(): View = binding.syncIndicator
+    override fun getRefreshFab(): View = binding.fabRefresh
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/SweetPotatoMarketFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/SweetPotatoMarketFragment.kt
@@ -1,0 +1,41 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.akilimo.mobile.R
+import com.akilimo.mobile.base.AbstractProduceMarketFragment
+import com.akilimo.mobile.databinding.ActivitySweetPotatoMarketBinding
+import com.akilimo.mobile.enums.EnumMarketType
+import com.akilimo.mobile.enums.EnumProduceType
+import com.akilimo.mobile.enums.EnumUnitOfSale
+import com.akilimo.mobile.ui.components.ProduceMarketViews
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SweetPotatoMarketFragment : AbstractProduceMarketFragment<ActivitySweetPotatoMarketBinding>(
+    marketType = EnumMarketType.SWEET_POTATO_MARKET,
+    titleRes = R.string.lbl_sweet_potato_market
+) {
+
+    override val views: ProduceMarketViews
+        get() = ProduceMarketViews.Binding(
+            unitLabel = binding.unitLabel,
+            unitInputLayout = binding.unitInputLayout,
+            unitSpinner = binding.unitSpinner,
+            inputPrice = binding.inputPrice,
+            priceInputLayout = binding.priceInputLayout,
+            fabSave = binding.lytFab.fabSave,
+            marketHintCard = binding.marketHintCard,
+            marketHintText = binding.marketHintText,
+            toolbar = binding.lytToolbar.toolbar
+        )
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivitySweetPotatoMarketBinding.inflate(inflater, container, false)
+
+    override fun resolveProduceType() = EnumProduceType.SWEET_POTATO_TUBERS
+
+    override fun setupProduceTypeSelection() {
+        updateUnits { it.isUniversal }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/TractorAccessFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/TractorAccessFragment.kt
@@ -1,0 +1,147 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import androidx.core.os.bundleOf
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import com.akilimo.mobile.R
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityTractorAccessBinding
+import com.akilimo.mobile.entities.AdviceCompletionDto
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumStepStatus
+import com.akilimo.mobile.ui.viewmodels.TractorAccessViewModel
+import com.akilimo.mobile.utils.StringHelper
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class TractorAccessFragment : BaseFragment<ActivityTractorAccessBinding>() {
+
+    private val viewModel: TractorAccessViewModel by viewModels()
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityTractorAccessBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        setupTractorAccessToggle()
+        setupImplementToggle()
+
+        binding.apply {
+            lytFabButton.fabSave.setOnClickListener {
+                viewModel.saveCosts(
+                    isTractorAvailable(),
+                    etTractorRidgeCost.text?.toString()?.toDoubleOrNull(),
+                    etTractorPloughCost.text?.toString()?.toDoubleOrNull(),
+                    etTractorHarrowCost.text?.toString()?.toDoubleOrNull()
+                )
+            }
+            etTractorPloughCost.addTextChangedListener { toggleFab() }
+            etTractorRidgeCost.addTextChangedListener { toggleFab() }
+            etTractorHarrowCost.addTextChangedListener { toggleFab() }
+            lytFabButton.fabSave.hide()
+        }
+
+        observeViewModel()
+        viewModel.loadData(sessionManager.akilimoUser)
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    if (state.saved) {
+                        val completion = AdviceCompletionDto(EnumAdviceTask.MANUAL_TILLAGE_COST, EnumStepStatus.COMPLETED)
+                        parentFragmentManager.setFragmentResult(
+                            UseCaseResults.ADVICE_COMPLETION,
+                            bundleOf(UseCaseResults.ADVICE_COMPLETION_DTO to completion)
+                        )
+                        viewModel.onSaveHandled()
+                        findNavController().popBackStack()
+                        return@collect
+                    }
+
+                    if (state.userId == 0) return@collect
+
+                    val sizeUnitLabel = state.enumAreaUnit.label(requireContext()).orEmpty()
+                    binding.apply {
+                        tilTractorPloughCost.hint = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_tractor_plough_cost_hint, state.farmSize, sizeUnitLabel) } }
+                        tilTractorRidgeCost.hint = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_tractor_ridge_cost_hint, state.farmSize, sizeUnitLabel) } }
+                        tilTractorHarrowCost.hint = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_tractor_harrow_cost_hint, state.farmSize, sizeUnitLabel) } }
+                        if (etTractorRidgeCost.text.isNullOrEmpty()) etTractorRidgeCost.setText(state.tractorRidgeCost.toString())
+                        if (etTractorPloughCost.text.isNullOrEmpty()) etTractorPloughCost.setText(state.tractorPloughCost.toString())
+                        if (etTractorHarrowCost.text.isNullOrEmpty()) etTractorHarrowCost.setText(state.tractorHarrowCost.toString())
+                        if (state.tractorPloughCost > 0.0) { toggleGroupImplements.check(R.id.btn_impl_plough); tilTractorPloughCost.visibility = View.VISIBLE }
+                        if (state.tractorRidgeCost > 0.0) { toggleGroupImplements.check(R.id.btn_impl_ridge); tilTractorRidgeCost.visibility = View.VISIBLE }
+                        if (state.tractorHarrowCost > 0.0) { toggleGroupImplements.check(R.id.btn_impl_harrow); tilTractorHarrowCost.visibility = View.VISIBLE }
+                        toggleTractorAccess.check(if (state.tractorAvailable) R.id.btn_yes else R.id.btn_no)
+                    }
+                    toggleFab()
+                }
+            }
+        }
+    }
+
+    private fun setupTractorAccessToggle() = with(binding) {
+        toggleTractorAccess.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            if (isChecked) {
+                when (checkedId) {
+                    R.id.btn_yes -> { tvImplementsHeader.visibility = View.VISIBLE; toggleGroupImplements.visibility = View.VISIBLE }
+                    R.id.btn_no -> {
+                        tvImplementsHeader.visibility = View.GONE; toggleGroupImplements.visibility = View.GONE
+                        toggleGroupImplements.clearChecked()
+                        toggleField(false, tilTractorPloughCost, etTractorPloughCost)
+                        toggleField(false, tilTractorRidgeCost, etTractorRidgeCost)
+                        toggleField(false, tilTractorHarrowCost, etTractorHarrowCost)
+                    }
+                }
+                toggleFab()
+            }
+        }
+    }
+
+    private fun setupImplementToggle() = with(binding) {
+        toggleGroupImplements.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            when (checkedId) {
+                R.id.btn_impl_plough -> toggleField(isChecked, tilTractorPloughCost, etTractorPloughCost)
+                R.id.btn_impl_ridge -> toggleField(isChecked, tilTractorRidgeCost, etTractorRidgeCost)
+                R.id.btn_impl_harrow -> toggleField(isChecked, tilTractorHarrowCost, etTractorHarrowCost)
+            }
+            toggleFab()
+        }
+    }
+
+    private fun isTractorAvailable() = binding.toggleTractorAccess.checkedButtonId == R.id.btn_yes
+
+    private fun hasFormChanged(): Boolean {
+        val state = viewModel.uiState.value
+        if (state.userId == 0) return false
+        fun parse(text: CharSequence?) = text?.toString()?.toDoubleOrNull()?.takeIf { it >= 0 }
+        val checks = binding.toggleGroupImplements.checkedButtonIds
+        return (parse(binding.etTractorPloughCost.text)?.let { it != state.tractorPloughCost } ?: false) ||
+               (parse(binding.etTractorRidgeCost.text)?.let { it != state.tractorRidgeCost } ?: false) ||
+               (parse(binding.etTractorHarrowCost.text)?.let { it != state.tractorHarrowCost } ?: false) ||
+               isTractorAvailable() != state.tractorAvailable ||
+               checks.contains(R.id.btn_impl_plough) != (state.tractorPloughCost > 0.0) ||
+               checks.contains(R.id.btn_impl_ridge) != (state.tractorRidgeCost > 0.0) ||
+               checks.contains(R.id.btn_impl_harrow) != (state.tractorHarrowCost > 0.0)
+    }
+
+    private fun toggleField(isChecked: Boolean, layout: View, editText: EditText) {
+        layout.visibility = if (isChecked) View.VISIBLE else View.GONE
+        if (!isChecked) editText.text = null
+    }
+
+    private fun toggleFab() {
+        val show = viewModel.uiState.value.let { it.userId != 0 && (!it.tractorAvailable || hasFormChanged()) }
+        binding.lytFabButton.fabSave.apply { if (show) show() else hide() }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/UseCaseResults.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/UseCaseResults.kt
@@ -1,0 +1,10 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+/**
+ * Fragment Result API keys shared between use-case Fragments and their
+ * parent recommendation Fragments (FrFragment, BppFragment, etc.).
+ */
+object UseCaseResults {
+    const val ADVICE_COMPLETION = "advice_completion"
+    const val ADVICE_COMPLETION_DTO = "dto"
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/UserSettingsFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/UserSettingsFragment.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -57,7 +58,7 @@ class UserSettingsFragment : BaseFragment<ActivityUserSettingsBinding>() {
         appCompatActivity.setSupportActionBar(binding.toolbar)
         appCompatActivity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
         binding.toolbar.setNavigationOnClickListener {
-            requireActivity().onBackPressedDispatcher.onBackPressed()
+            findNavController().popBackStack()
         }
     }
 

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/UserSettingsFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/UserSettingsFragment.kt
@@ -1,0 +1,217 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.util.Patterns
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.akilimo.mobile.Locales
+import com.akilimo.mobile.R
+import com.akilimo.mobile.adapters.ValueOptionAdapter
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityUserSettingsBinding
+import com.akilimo.mobile.dto.AreaUnitOption
+import com.akilimo.mobile.dto.CountryOption
+import com.akilimo.mobile.dto.InterestOption
+import com.akilimo.mobile.dto.findByValue
+import com.akilimo.mobile.entities.UserPreferences
+import com.akilimo.mobile.enums.EnumAreaUnit
+import com.akilimo.mobile.enums.EnumCountry
+import com.akilimo.mobile.ui.viewmodels.UserSettingsViewModel
+import com.google.android.material.snackbar.Snackbar
+import dagger.hilt.android.AndroidEntryPoint
+import dev.b3nedikt.app_locale.AppLocale
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@AndroidEntryPoint
+class UserSettingsFragment : BaseFragment<ActivityUserSettingsBinding>() {
+
+    private val viewModel: UserSettingsViewModel by viewModels()
+
+    private lateinit var genderOptions: List<InterestOption>
+    private lateinit var languageOptions: List<InterestOption>
+    private lateinit var countryOptions: List<CountryOption>
+    private lateinit var areaUnitOptions: List<AreaUnitOption>
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityUserSettingsBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        setupToolbar()
+        setupDropdownOptions()
+        setupDropdownAdapters()
+        setupSaveButton()
+        observeViewModel()
+        viewModel.loadPreferences()
+    }
+
+    private fun setupToolbar() {
+        val appCompatActivity = requireActivity() as AppCompatActivity
+        appCompatActivity.setSupportActionBar(binding.toolbar)
+        appCompatActivity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.toolbar.setNavigationOnClickListener {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+        }
+    }
+
+    private fun setupDropdownOptions() {
+        genderOptions = listOf(
+            InterestOption(getString(R.string.lbl_gender_prompt), ""),
+            InterestOption(getString(R.string.lbl_female), "F"),
+            InterestOption(getString(R.string.lbl_male), "M"),
+            InterestOption(getString(R.string.lbl_prefer_not_to_say), "NA")
+        )
+        languageOptions = Locales.supportedLocales.map {
+            InterestOption(it.getDisplayLanguage(it), it.toLanguageTag())
+        }
+        countryOptions = EnumCountry.entries
+            .filter { it != EnumCountry.Unsupported }
+            .map { CountryOption(it.countryName, it, it.currencyCode) }
+        areaUnitOptions = EnumAreaUnit.entries.map { unit ->
+            AreaUnitOption(unit.label(requireContext()), unit)
+        }
+    }
+
+    private fun setupDropdownAdapters() {
+        val genderAdapter = ValueOptionAdapter(requireContext(), genderOptions)
+        binding.dropGender.setAdapter(genderAdapter)
+        binding.dropGender.setOnItemClickListener { _, _, position, _ ->
+            genderAdapter.getItem(position)?.let { binding.dropGender.setText(it.displayLabel, false) }
+        }
+
+        val languageAdapter = ValueOptionAdapter(requireContext(), languageOptions)
+        binding.dropLanguage.setAdapter(languageAdapter)
+        binding.dropLanguage.setOnItemClickListener { _, _, position, _ ->
+            languageAdapter.getItem(position)?.let { binding.dropLanguage.setText(it.displayLabel, false) }
+        }
+
+        val countryAdapter = ValueOptionAdapter(requireContext(), countryOptions)
+        binding.dropCountry.setAdapter(countryAdapter)
+        binding.dropCountry.setOnItemClickListener { _, _, position, _ ->
+            countryAdapter.getItem(position)?.let { binding.dropCountry.setText(it.displayLabel, false) }
+        }
+
+        val areaUnitAdapter = ValueOptionAdapter(requireContext(), areaUnitOptions)
+        binding.dropAreaUnit.setAdapter(areaUnitAdapter)
+        binding.dropAreaUnit.setOnItemClickListener { _, _, position, _ ->
+            areaUnitAdapter.getItem(position)?.let { binding.dropAreaUnit.setText(it.displayLabel, false) }
+        }
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    state.preferences?.let { populateForm(it) }
+
+                    if (state.saved) {
+                        Snackbar.make(binding.root, R.string.lbl_settings_saved, Snackbar.LENGTH_SHORT).show()
+                        Timber.d("User preferences saved")
+
+                        val selectedLocale = Locales.supportedLocales
+                            .find { it.toLanguageTag() == state.newLanguageCode }
+                            ?: Locales.english
+                        AppLocale.desiredLocale = selectedLocale
+
+                        AppCompatDelegate.setDefaultNightMode(
+                            if (state.preferences?.darkMode == true) AppCompatDelegate.MODE_NIGHT_YES
+                            else AppCompatDelegate.MODE_NIGHT_NO
+                        )
+
+                        if (state.languageChanged) {
+                            AppCompatDelegate.setApplicationLocales(
+                                LocaleListCompat.forLanguageTags(state.newLanguageCode)
+                            )
+                        }
+
+                        viewModel.onSaveHandled()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun populateForm(prefs: UserPreferences) = with(binding) {
+        edtFirstName.setText(prefs.firstName)
+        edtLastName.setText(prefs.lastName)
+        edtBio.setText(prefs.bio)
+        edtEmail.setText(prefs.email)
+        edtPhone.setText(prefs.phoneNumber)
+
+        prefs.phoneCountryCode?.let { code ->
+            if (code.isNotBlank()) {
+                ccpCountry.setCountryForPhoneCode(
+                    code.removePrefix("+").toIntOrNull() ?: return@let
+                )
+            }
+        }
+        ccpCountry.registerCarrierNumberEditText(edtPhone)
+
+        dropGender.setText(genderOptions.find { it.valueOption == prefs.gender }?.displayLabel ?: "", false)
+        dropLanguage.setText(languageOptions.find { it.valueOption == prefs.languageCode }?.displayLabel ?: "", false)
+        dropCountry.setText(countryOptions.findByValue(prefs.country)?.displayLabel ?: "", false)
+        dropAreaUnit.setText(areaUnitOptions.findByValue(prefs.preferredAreaUnit)?.displayLabel ?: "", false)
+
+        switchNotifyEmail.isChecked = prefs.notifyByEmail
+        switchNotifySms.isChecked = prefs.notifyBySms
+        switchDarkMode.isChecked = prefs.darkMode
+    }
+
+    private fun setupSaveButton() {
+        binding.btnSaveSettings.setOnClickListener { validateAndSave() }
+    }
+
+    private fun validateAndSave() = with(binding) {
+        lytFirstName.error = null
+        lytEmail.error = null
+        lytPhone.error = null
+
+        val firstName = edtFirstName.text.toString().trim()
+        val lastName = edtLastName.text.toString().trim()
+        val email = edtEmail.text.toString().trim()
+        val hasPhoneInput = edtPhone.text?.isNotBlank() == true
+        val phone = if (hasPhoneInput) ccpCountry.fullNumber else ""
+        val phoneCountryCode = if (hasPhoneInput) ccpCountry.selectedCountryCodeWithPlus else ""
+
+        if (email.isNotBlank() && !Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+            lytEmail.error = getString(R.string.lbl_valid_email_req); return@with
+        }
+        if (hasPhoneInput && !Patterns.PHONE.matcher(phone).matches()) {
+            lytPhone.error = getString(R.string.lbl_valid_number_req); return@with
+        }
+
+        val gender = genderOptions.find { it.displayLabel == dropGender.text.toString() }?.valueOption.orEmpty()
+        val langCode = languageOptions.find { it.displayLabel == dropLanguage.text.toString() }?.valueOption
+            ?: Locales.english.toLanguageTag()
+        val country = countryOptions.find { it.displayLabel == dropCountry.text.toString() }?.valueOption
+            ?: EnumCountry.Unsupported
+        val areaUnit = areaUnitOptions.find { it.displayLabel == dropAreaUnit.text.toString() }?.valueOption
+            ?: EnumAreaUnit.ACRE
+
+        viewModel.savePreferences(
+            UserPreferences(
+                languageCode = langCode,
+                firstName = firstName.ifBlank { null },
+                lastName = lastName.ifBlank { null },
+                email = email.ifBlank { null },
+                phoneNumber = phone.ifBlank { null },
+                phoneCountryCode = phoneCountryCode.ifBlank { null },
+                gender = gender.ifBlank { null },
+                country = country,
+                bio = edtBio.text.toString().trim().ifBlank { null },
+                notifyByEmail = switchNotifyEmail.isChecked,
+                notifyBySms = switchNotifySms.isChecked,
+                preferredAreaUnit = areaUnit,
+                darkMode = switchDarkMode.isChecked
+            ),
+            sessionManager.akilimoUser
+        )
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/WeedControlCostsFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/WeedControlCostsFragment.kt
@@ -1,0 +1,113 @@
+package com.akilimo.mobile.ui.fragments.usecases
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import com.akilimo.mobile.adapters.BaseValueOptionAdapter
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.databinding.ActivityWeedControlCostsBinding
+import com.akilimo.mobile.dto.WeedControlOption
+import com.akilimo.mobile.entities.AdviceCompletionDto
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumStepStatus
+import com.akilimo.mobile.enums.EnumWeedControlMethod
+import com.akilimo.mobile.ui.viewmodels.WeedControlCostsViewModel
+import com.akilimo.mobile.utils.StringHelper
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import com.akilimo.mobile.R
+
+@AndroidEntryPoint
+class WeedControlCostsFragment : BaseFragment<ActivityWeedControlCostsBinding>() {
+
+    private val viewModel: WeedControlCostsViewModel by viewModels()
+    private val weedControlOptions = mutableListOf<WeedControlOption>()
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+        ActivityWeedControlCostsBinding.inflate(inflater, container, false)
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        weedControlOptions.addAll(listOf(
+            WeedControlOption(EnumWeedControlMethod.MANUAL),
+            WeedControlOption(EnumWeedControlMethod.HERBICIDE),
+            WeedControlOption(EnumWeedControlMethod.HERBICIDE_AND_MANUAL)
+        ))
+
+        val adapter = BaseValueOptionAdapter(
+            requireContext(), weedControlOptions,
+            getDisplayText = { it.label(requireContext()) }
+        )
+
+        binding.apply {
+            dropWeedControl.setAdapter(adapter)
+            dropWeedControl.setOnItemClickListener { _, _, position, _ ->
+                val selected = weedControlOptions.getOrNull(position) ?: return@setOnItemClickListener
+                dropWeedControl.setText(selected.valueOption.label(requireContext()), false)
+            }
+            lytFabButton.fabSave.setOnClickListener {
+                val firstCost = etFirstWeedingCost.text?.toString()?.toDoubleOrNull()
+                val secondCost = etSecondWeedingCost.text?.toString()?.toDoubleOrNull()
+                viewModel.saveCosts(firstCost, secondCost)
+            }
+            etFirstWeedingCost.addTextChangedListener { toggleFab() }
+            etSecondWeedingCost.addTextChangedListener { toggleFab() }
+            lytFabButton.fabSave.hide()
+        }
+
+        observeViewModel()
+        viewModel.loadData(sessionManager.akilimoUser)
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    if (state.saved) {
+                        val completion = AdviceCompletionDto(EnumAdviceTask.COST_OF_WEED_CONTROL, EnumStepStatus.COMPLETED)
+                        parentFragmentManager.setFragmentResult(
+                            UseCaseResults.ADVICE_COMPLETION,
+                            bundleOf(UseCaseResults.ADVICE_COMPLETION_DTO to completion)
+                        )
+                        viewModel.onSaveHandled()
+                        findNavController().popBackStack()
+                        return@collect
+                    }
+
+                    if (state.userId == 0) return@collect
+
+                    val sizeUnitLabel = state.enumAreaUnit.label(requireContext()).orEmpty()
+                    binding.apply {
+                        tilFirstWeedingCost.helperText = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_cost_of_first_weeding_operation, state.farmSize, sizeUnitLabel) } }
+                        tilSecondWeedingCost.helperText = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_cost_of_second_weeding_operation, state.farmSize, sizeUnitLabel) } }
+                        if (etFirstWeedingCost.text.isNullOrEmpty()) etFirstWeedingCost.setText(state.firstWeedingCost.toString())
+                        if (etSecondWeedingCost.text.isNullOrEmpty()) etSecondWeedingCost.setText(state.secondWeedingCost.toString())
+                        state.weedControlMethod?.let { dropWeedControl.setText(it.label(requireContext()), false) }
+                    }
+                    toggleFab()
+                }
+            }
+        }
+    }
+
+    private fun hasFormChanged(): Boolean {
+        val state = viewModel.uiState.value
+        if (state.userId == 0) return false
+        fun parse(text: CharSequence?) = text?.toString()?.toDoubleOrNull()?.takeIf { it >= 0 }
+        val first = parse(binding.etFirstWeedingCost.text)
+        val second = parse(binding.etSecondWeedingCost.text)
+        return (first != null && first != state.firstWeedingCost) || (second != null && second != state.secondWeedingCost)
+    }
+
+    private fun toggleFab() {
+        val state = viewModel.uiState.value
+        val show = state.userId != 0 && (state.firstWeedingCost == 0.0 || hasFormChanged())
+        binding.lytFabButton.fabSave.apply { if (show) show() else hide() }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/WeedControlCostsFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/WeedControlCostsFragment.kt
@@ -29,6 +29,7 @@ class WeedControlCostsFragment : BaseFragment<ActivityWeedControlCostsBinding>()
 
     private val viewModel: WeedControlCostsViewModel by viewModels()
     private val weedControlOptions = mutableListOf<WeedControlOption>()
+    private var selectedWeedControlMethod: EnumWeedControlMethod? = null
 
     override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
         ActivityWeedControlCostsBinding.inflate(inflater, container, false)
@@ -49,12 +50,13 @@ class WeedControlCostsFragment : BaseFragment<ActivityWeedControlCostsBinding>()
             dropWeedControl.setAdapter(adapter)
             dropWeedControl.setOnItemClickListener { _, _, position, _ ->
                 val selected = weedControlOptions.getOrNull(position) ?: return@setOnItemClickListener
+                selectedWeedControlMethod = selected.valueOption
                 dropWeedControl.setText(selected.valueOption.label(requireContext()), false)
             }
             lytFabButton.fabSave.setOnClickListener {
                 val firstCost = etFirstWeedingCost.text?.toString()?.toDoubleOrNull()
                 val secondCost = etSecondWeedingCost.text?.toString()?.toDoubleOrNull()
-                viewModel.saveCosts(firstCost, secondCost)
+                viewModel.saveCosts(firstCost, secondCost, selectedWeedControlMethod)
             }
             etFirstWeedingCost.addTextChangedListener { toggleFab() }
             etSecondWeedingCost.addTextChangedListener { toggleFab() }
@@ -88,7 +90,10 @@ class WeedControlCostsFragment : BaseFragment<ActivityWeedControlCostsBinding>()
                         tilSecondWeedingCost.helperText = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_cost_of_second_weeding_operation, state.farmSize, sizeUnitLabel) } }
                         if (etFirstWeedingCost.text.isNullOrEmpty()) etFirstWeedingCost.setText(state.firstWeedingCost.toString())
                         if (etSecondWeedingCost.text.isNullOrEmpty()) etSecondWeedingCost.setText(state.secondWeedingCost.toString())
-                        state.weedControlMethod?.let { dropWeedControl.setText(it.label(requireContext()), false) }
+                        state.weedControlMethod?.let {
+                        if (selectedWeedControlMethod == null) selectedWeedControlMethod = it
+                        dropWeedControl.setText(it.label(requireContext()), false)
+                    }
                     }
                     toggleFab()
                 }

--- a/app/src/main/java/com/akilimo/mobile/ui/usecases/WeedControlCostsActivity.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/usecases/WeedControlCostsActivity.kt
@@ -28,6 +28,7 @@ class WeedControlCostsActivity : BaseActivity<ActivityWeedControlCostsBinding>()
     private val viewModel: WeedControlCostsViewModel by viewModels()
 
     private val weedControlOptions = mutableListOf<WeedControlOption>()
+    private var selectedWeedControlMethod: EnumWeedControlMethod? = null
 
     override fun inflateBinding() = ActivityWeedControlCostsBinding.inflate(layoutInflater)
 
@@ -47,6 +48,7 @@ class WeedControlCostsActivity : BaseActivity<ActivityWeedControlCostsBinding>()
             dropWeedControl.setAdapter(areaUnitAdapter)
             dropWeedControl.setOnItemClickListener { _, _, position, _ ->
                 val selected = weedControlOptions.getOrNull(position) ?: return@setOnItemClickListener
+                selectedWeedControlMethod = selected.valueOption
                 dropWeedControl.setText(
                     selected.valueOption.label(this@WeedControlCostsActivity), false
                 )
@@ -54,7 +56,7 @@ class WeedControlCostsActivity : BaseActivity<ActivityWeedControlCostsBinding>()
             lytFabButton.fabSave.setOnClickListener {
                 val firstCost = etFirstWeedingCost.text?.toString()?.toDoubleOrNull()
                 val secondCost = etSecondWeedingCost.text?.toString()?.toDoubleOrNull()
-                viewModel.saveCosts(firstCost, secondCost)
+                viewModel.saveCosts(firstCost, secondCost, selectedWeedControlMethod)
             }
             etFirstWeedingCost.addTextChangedListener { toggleFab() }
             etSecondWeedingCost.addTextChangedListener { toggleFab() }
@@ -98,6 +100,7 @@ class WeedControlCostsActivity : BaseActivity<ActivityWeedControlCostsBinding>()
                         }
 
                         state.weedControlMethod?.let { method ->
+                            if (selectedWeedControlMethod == null) selectedWeedControlMethod = method
                             dropWeedControl.setText(method.label(this@WeedControlCostsActivity), false)
                         }
                     }

--- a/app/src/main/java/com/akilimo/mobile/ui/usecases/fertilizer/BaseFertilizerFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/usecases/fertilizer/BaseFertilizerFragment.kt
@@ -3,6 +3,7 @@ package com.akilimo.mobile.ui.usecases.fertilizer
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -58,6 +59,12 @@ abstract class BaseFertilizerFragment<VB : ViewBinding> : BaseFragment<VB>() {
     )
 
     override fun onBindingReady(savedInstanceState: Bundle?) {
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() = handleBackNavigation()
+            }
+        )
         initHelpers()
         setupToolbar()
         setupRecycler()

--- a/app/src/main/java/com/akilimo/mobile/ui/usecases/fertilizer/BaseFertilizerFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/usecases/fertilizer/BaseFertilizerFragment.kt
@@ -1,0 +1,197 @@
+package com.akilimo.mobile.ui.usecases.fertilizer
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.view.View
+import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.akilimo.mobile.R
+import com.akilimo.mobile.base.BaseFragment
+import com.akilimo.mobile.entities.AdviceCompletionDto
+import com.akilimo.mobile.entities.Fertilizer
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumFertilizerFlow
+import com.akilimo.mobile.ui.components.ToolbarHelper
+import com.akilimo.mobile.ui.fragments.usecases.UseCaseResults
+import com.akilimo.mobile.ui.viewmodels.FertilizerViewModel
+import com.akilimo.mobile.workers.FertilizerWorker
+import com.akilimo.mobile.workers.WorkConstants
+import com.akilimo.mobile.workers.WorkerScheduler
+import com.google.android.material.snackbar.Snackbar
+import dagger.hilt.android.lifecycle.withCreationCallback
+import kotlinx.coroutines.launch
+
+abstract class BaseFertilizerFragment<VB : ViewBinding> : BaseFragment<VB>() {
+
+    protected val gridSpanCount by lazy { resources.getInteger(R.integer.grid_span_count_default) }
+
+    abstract val adviseTask: EnumAdviceTask
+    open val toolbarMenuRes: Int? = R.menu.menu_fertilizers
+    open val enableLayoutToggle: Boolean = true
+    open val enableRefreshFab: Boolean = true
+    open val fertilizerFlow: EnumFertilizerFlow get() = EnumFertilizerFlow.DEFAULT
+
+    abstract fun getToolbar(): androidx.appcompat.widget.Toolbar
+    abstract fun getRecyclerView(): RecyclerView
+    abstract fun getRootView(): View
+    abstract fun getEmptyStateView(): View?
+    open fun getSyncIndicator(): View? = null
+    open fun getRefreshFab(): View? = null
+
+    protected lateinit var listManager: FertilizerListManager
+    protected lateinit var selectionHelper: FertilizerSelectionHelper
+
+    protected val viewModel: FertilizerViewModel by viewModels(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<FertilizerViewModel.Factory> { factory ->
+                factory.create(sessionManager.akilimoUser, fertilizerFlow)
+            }
+        }
+    )
+
+    override fun onBindingReady(savedInstanceState: Bundle?) {
+        initHelpers()
+        setupToolbar()
+        setupRecycler()
+        setupRefreshFab()
+        observeSyncWorker()
+        observeViewModel()
+    }
+
+    private fun initHelpers() {
+        listManager = FertilizerListManager(
+            recyclerView = getRecyclerView(),
+            gridSpanCount = gridSpanCount
+        )
+        selectionHelper = FertilizerSelectionHelper(
+            lifecycleScope = safeScope,
+            priceRepo = viewModel.priceRepo,
+            selectedRepo = viewModel.selectedRepo
+        )
+    }
+
+    private fun setupToolbar() {
+        val helper = ToolbarHelper(
+            requireActivity() as androidx.appcompat.app.AppCompatActivity,
+            getToolbar()
+        )
+            .showBackButton(true)
+            .onNavigationClick { handleBackNavigation() }
+
+        toolbarMenuRes?.let { menuRes ->
+            helper.inflateMenu(menuRes) { item -> onToolbarMenuItemClicked(item) }
+        }
+        helper.build()
+    }
+
+    protected open fun onToolbarMenuItemClicked(item: MenuItem) {
+        if (enableLayoutToggle && item.itemId == R.id.action_toggle_layout) {
+            val isGrid = listManager.toggleLayout()
+            sessionManager.isFertilizerGrid = isGrid
+            item.setIcon(if (isGrid) R.drawable.ic_list else R.drawable.ic_grid)
+        }
+    }
+
+    private fun setupRecycler() {
+        listManager.initialize(
+            initialGridMode = sessionManager.isFertilizerGrid,
+            onItemClick = { fertilizer -> showPriceBottomSheet(fertilizer) }
+        )
+    }
+
+    private fun setupRefreshFab() {
+        if (!enableRefreshFab) return
+        getRefreshFab()?.setOnClickListener {
+            it.isEnabled = false
+            WorkerScheduler.scheduleOneTimeWorker<FertilizerWorker>(
+                context = requireContext(),
+                workName = WorkConstants.FERTILIZER_WORK_NAME
+            )
+        }
+    }
+
+    private fun observeViewModel() {
+        safeScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    listManager.adapter.submitList(state.fertilizers)
+                    listManager.adapter.updateSelection(state.selectedIds)
+                    showEmptyState(state.isEmpty)
+                }
+            }
+        }
+    }
+
+    private fun showPriceBottomSheet(fertilizer: Fertilizer) {
+        selectionHelper.showPriceBottomSheet(
+            fertilizer = fertilizer,
+            userId = viewModel.uiState.value.userId,
+            fragmentManager = childFragmentManager,
+            onSelectionChanged = { fertilizerId, fertilizerPriceId, price, displayPrice, isSelected, isExactPrice ->
+                listManager.updateItemSelection(fertilizerId, price, displayPrice, isSelected)
+                if (isSelected) {
+                    viewModel.selectFertilizer(fertilizerId, fertilizerPriceId, price, displayPrice, isExactPrice)
+                } else {
+                    viewModel.deselectFertilizer(fertilizerId)
+                }
+            }
+        )
+    }
+
+    private fun showEmptyState(isEmpty: Boolean) {
+        getEmptyStateView()?.isVisible = isEmpty
+        getRecyclerView().isVisible = !isEmpty
+    }
+
+    private fun observeSyncWorker() {
+        WorkManager.getInstance(requireContext())
+            .getWorkInfosForUniqueWorkLiveData(WorkConstants.FERTILIZER_WORK_NAME)
+            .observe(viewLifecycleOwner) { infos ->
+                infos?.firstOrNull()?.let { handleWorkerState(it) }
+            }
+    }
+
+    private fun handleWorkerState(workInfo: WorkInfo) {
+        when (workInfo.state) {
+            WorkInfo.State.ENQUEUED, WorkInfo.State.RUNNING -> showSyncIndicator(true)
+            WorkInfo.State.SUCCEEDED -> {
+                showSyncIndicator(false)
+                getRefreshFab()?.isEnabled = true
+                val saved = workInfo.outputData.getInt("savedCount", 0)
+                Snackbar.make(
+                    getRootView(),
+                    getString(R.string.fertilizers_synced, saved),
+                    Snackbar.LENGTH_SHORT
+                ).show()
+            }
+            else -> {
+                showSyncIndicator(false)
+                getRefreshFab()?.isEnabled = true
+            }
+        }
+    }
+
+    private fun showSyncIndicator(visible: Boolean) {
+        getSyncIndicator()?.isVisible = visible
+    }
+
+    private fun handleBackNavigation() {
+        safeScope.launch {
+            val status = viewModel.getStepStatus()
+            val completion = AdviceCompletionDto(taskName = adviseTask, stepStatus = status)
+            parentFragmentManager.setFragmentResult(
+                UseCaseResults.ADVICE_COMPLETION,
+                bundleOf(UseCaseResults.ADVICE_COMPLETION_DTO to completion)
+            )
+            findNavController().popBackStack()
+        }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/viewmodels/WeedControlCostsViewModel.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/viewmodels/WeedControlCostsViewModel.kt
@@ -2,6 +2,7 @@ package com.akilimo.mobile.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.akilimo.mobile.entities.CurrentPractice
 import com.akilimo.mobile.entities.FieldOperationCost
 import com.akilimo.mobile.enums.EnumAreaUnit
 import com.akilimo.mobile.enums.EnumWeedControlMethod
@@ -53,7 +54,7 @@ class WeedControlCostsViewModel @Inject constructor(
         }
     }
 
-    fun saveCosts(firstCost: Double?, secondCost: Double?) = viewModelScope.launch {
+    fun saveCosts(firstCost: Double?, secondCost: Double?, method: EnumWeedControlMethod?) = viewModelScope.launch {
         val userId = _uiState.value.userId.takeIf { it != 0 } ?: return@launch
         val newCosts = FieldOperationCost(
             userId = userId,
@@ -66,6 +67,15 @@ class WeedControlCostsViewModel @Inject constructor(
             secondWeedingOperationCost = if (secondCost != null) newCosts.secondWeedingOperationCost else existing.secondWeedingOperationCost,
         ) ?: newCosts
         costsRepo.saveCost(merged)
+
+        if (method != null) {
+            val practice = currentPracticeRepo.getPracticeForUser(userId)
+            val updatedPractice = practice?.copy(weedControlMethod = method)
+                ?: CurrentPractice(userId = userId, weedControlMethod = method)
+            currentPracticeRepo.savePractice(updatedPractice)
+            _uiState.update { it.copy(weedControlMethod = method) }
+        }
+
         _uiState.update { it.copy(saved = true) }
     }
 

--- a/app/src/main/java/com/akilimo/mobile/utils/RecommendationBuilder.kt
+++ b/app/src/main/java/com/akilimo/mobile/utils/RecommendationBuilder.kt
@@ -73,11 +73,12 @@ class RecommendationBuilder(
             costRidging = fieldOperations?.manualRidgeCost ?: 0.0
         )
         val practice = currentPracticeRepo.getPracticeForUser(profile.id ?: 0)
+        val weedMethod = practice?.weedControlMethod ?: profile.weedControlMethod
         val operationMethods = ComputeRequest.Methods(
             methodPloughing = practice?.ploughingMethod.orUnavailable(DEFAULT_UNAVAILABLE),
             methodHarrowing = practice?.harrowingMethod.orUnavailable(DEFAULT_UNAVAILABLE),
             methodRidging = practice?.ridgingMethod.orUnavailable(DEFAULT_UNAVAILABLE),
-            methodWeeding = practice?.weedControlMethod?.name.orUnavailable(DEFAULT_UNAVAILABLE),
+            methodWeeding = weedMethod?.name.orUnavailable(DEFAULT_UNAVAILABLE),
         )
 
 

--- a/app/src/main/res/navigation/nav_recommendations.xml
+++ b/app/src/main/res/navigation/nav_recommendations.xml
@@ -56,4 +56,76 @@
         android:name="com.akilimo.mobile.ui.fragments.IcSweetPotatoFragment"
         android:label="Intercropping Sweet Potato" />
 
+    <!-- Use-case fragments navigated to from recommendation sub-screens -->
+
+    <fragment
+        android:id="@+id/fertilizerFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.FertilizersFragment"
+        android:label="Fertilizers" />
+
+    <fragment
+        android:id="@+id/interCropFertilizersFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.InterCropFertilizersFragment"
+        android:label="Intercrop Fertilizers" />
+
+    <fragment
+        android:id="@+id/sweetPotatoInterCropFertilizersFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.SweetPotatoInterCropFertilizersFragment"
+        android:label="Sweet Potato Intercrop Fertilizers" />
+
+    <fragment
+        android:id="@+id/investmentAmountFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.InvestmentAmountFragment"
+        android:label="Investment Amount" />
+
+    <fragment
+        android:id="@+id/cassavaMarketFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.CassavaMarketFragment"
+        android:label="Cassava Market" />
+
+    <fragment
+        android:id="@+id/cassavaYieldFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.CassavaYieldFragment"
+        android:label="Cassava Yield" />
+
+    <fragment
+        android:id="@+id/datesFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.DatesFragment"
+        android:label="Planting and Harvest Dates" />
+
+    <fragment
+        android:id="@+id/manualTillageCostFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.ManualTillageCostFragment"
+        android:label="Manual Tillage Cost" />
+
+    <fragment
+        android:id="@+id/tractorAccessFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.TractorAccessFragment"
+        android:label="Tractor Access" />
+
+    <fragment
+        android:id="@+id/weedControlCostsFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.WeedControlCostsFragment"
+        android:label="Weed Control Costs" />
+
+    <fragment
+        android:id="@+id/maizeMarketFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.MaizeMarketFragment"
+        android:label="Maize Market" />
+
+    <fragment
+        android:id="@+id/maizePerformanceFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.MaizePerformanceFragment"
+        android:label="Maize Performance" />
+
+    <fragment
+        android:id="@+id/sweetPotatoMarketFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.SweetPotatoMarketFragment"
+        android:label="Sweet Potato Market" />
+
+    <fragment
+        android:id="@+id/getRecommendationFragment"
+        android:name="com.akilimo.mobile.ui.fragments.usecases.GetRecommendationFragment"
+        android:label="Get Recommendation" />
+
 </navigation>

--- a/app/src/test/java/com/akilimo/mobile/navigation/RecommendationsNavGraphTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/navigation/RecommendationsNavGraphTest.kt
@@ -1,0 +1,122 @@
+package com.akilimo.mobile.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Validates that nav_recommendations.xml contains all required destinations and actions.
+ *
+ * These tests run on the JVM (no device needed) and guard against:
+ * - Accidental removal of a destination (would cause NavController to crash at runtime)
+ * - Missing actions from the start destination
+ */
+class RecommendationsNavGraphTest {
+
+    private val navFile = File("src/main/res/navigation/nav_recommendations.xml")
+
+    private fun parseFragmentIds(): Set<String> {
+        val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(navFile)
+        doc.documentElement.normalize()
+        val fragments = doc.getElementsByTagName("fragment")
+        return (0 until fragments.length)
+            .map { i ->
+                (fragments.item(i) as Element)
+                    .getAttribute("android:id")
+                    .removePrefix("@+id/")
+                    .removePrefix("@id/")
+            }
+            .filter { it.isNotEmpty() }
+            .toSet()
+    }
+
+    @Test
+    fun `nav_recommendations contains exactly 20 fragment destinations`() {
+        val ids = parseFragmentIds()
+        assertEquals(
+            "Expected 20 destinations — add one here if you add a new use-case fragment.\n  Found: $ids",
+            20, ids.size
+        )
+    }
+
+    @Test
+    fun `nav_recommendations contains all recommendation sub-screen fragments`() {
+        val ids = parseFragmentIds()
+        val required = setOf(
+            "recommendationsFragment",
+            "frFragment",
+            "bppFragment",
+            "sphFragment",
+            "icMaizeFragment",
+            "icSweetPotatoFragment"
+        )
+        assertTrue(
+            "Missing recommendation sub-fragments: ${required - ids}",
+            ids.containsAll(required)
+        )
+    }
+
+    @Test
+    fun `nav_recommendations contains all use-case destinations`() {
+        val ids = parseFragmentIds()
+        val required = setOf(
+            "fertilizerFragment",
+            "interCropFertilizersFragment",
+            "sweetPotatoInterCropFertilizersFragment",
+            "investmentAmountFragment",
+            "cassavaMarketFragment",
+            "cassavaYieldFragment",
+            "datesFragment",
+            "manualTillageCostFragment",
+            "tractorAccessFragment",
+            "weedControlCostsFragment",
+            "maizeMarketFragment",
+            "maizePerformanceFragment",
+            "sweetPotatoMarketFragment",
+            "getRecommendationFragment"
+        )
+        assertTrue(
+            "Missing use-case destinations: ${required - ids}",
+            ids.containsAll(required)
+        )
+    }
+
+    @Test
+    fun `recommendationsFragment has all navigation actions to sub-screens`() {
+        val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(navFile)
+        doc.documentElement.normalize()
+        val fragments = doc.getElementsByTagName("fragment")
+
+        var actionIds = emptySet<String>()
+        for (i in 0 until fragments.length) {
+            val element = fragments.item(i) as Element
+            val id = element.getAttribute("android:id")
+            if ("recommendationsFragment" in id) {
+                val actions = element.getElementsByTagName("action")
+                actionIds = (0 until actions.length)
+                    .map { j ->
+                        (actions.item(j) as Element)
+                            .getAttribute("android:id")
+                            .removePrefix("@+id/")
+                    }
+                    .toSet()
+                break
+            }
+        }
+
+        val required = setOf(
+            "action_recommendations_to_fr",
+            "action_recommendations_to_bpp",
+            "action_recommendations_to_sph",
+            "action_recommendations_to_icMaize",
+            "action_recommendations_to_icSweetPotato"
+        )
+        assertTrue(
+            "Missing actions in recommendationsFragment: ${required - actionIds}",
+            actionIds.containsAll(required)
+        )
+    }
+}

--- a/app/src/test/java/com/akilimo/mobile/ui/viewmodels/AdviceCompletionViewModelTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/ui/viewmodels/AdviceCompletionViewModelTest.kt
@@ -1,0 +1,102 @@
+package com.akilimo.mobile.ui.viewmodels
+
+import app.cash.turbine.test
+import com.akilimo.mobile.entities.AdviceCompletion
+import com.akilimo.mobile.entities.AdviceCompletionDto
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumStepStatus
+import com.akilimo.mobile.repos.AdviceCompletionRepo
+import com.akilimo.mobile.rules.TestDispatcherRule
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class AdviceCompletionViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = TestDispatcherRule()
+
+    private val repo: AdviceCompletionRepo = mockk(relaxed = true)
+    private lateinit var viewModel: AdviceCompletionViewModel
+
+    @Before
+    fun setUp() {
+        every { repo.getAllCompletions() } returns flowOf(emptyMap())
+        viewModel = AdviceCompletionViewModel(repo)
+    }
+
+    @Test
+    fun `completions emits empty map when repo has no data`() = runTest {
+        viewModel.completions.test {
+            assertEquals(emptyMap<String, AdviceCompletion>(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `completions exposes the flow from repo`() = runTest {
+        val completion = AdviceCompletion(
+            taskName = EnumAdviceTask.AVAILABLE_FERTILIZERS,
+            stepStatus = EnumStepStatus.COMPLETED
+        )
+        val expected = mapOf(EnumAdviceTask.AVAILABLE_FERTILIZERS.name to completion)
+        every { repo.getAllCompletions() } returns flowOf(expected)
+
+        val vm = AdviceCompletionViewModel(repo)
+        vm.completions.test {
+            assertEquals(expected, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `updateStatus delegates to repository`() = runTest {
+        val dto = AdviceCompletionDto(
+            taskName = EnumAdviceTask.AVAILABLE_FERTILIZERS,
+            stepStatus = EnumStepStatus.COMPLETED
+        )
+
+        viewModel.updateStatus(dto)
+        advanceUntilIdle()
+
+        coVerify { repo.updateStatus(dto) }
+    }
+
+    @Test
+    fun `updateStatus with IN_PROGRESS status delegates to repository`() = runTest {
+        val dto = AdviceCompletionDto(
+            taskName = EnumAdviceTask.PLANTING_AND_HARVEST,
+            stepStatus = EnumStepStatus.IN_PROGRESS
+        )
+
+        viewModel.updateStatus(dto)
+        advanceUntilIdle()
+
+        coVerify { repo.updateStatus(dto) }
+    }
+
+    @Test
+    fun `multiple updateStatus calls are each forwarded to the repo`() = runTest {
+        val tasks = listOf(
+            EnumAdviceTask.AVAILABLE_FERTILIZERS to EnumStepStatus.COMPLETED,
+            EnumAdviceTask.CASSAVA_MARKET_OUTLET to EnumStepStatus.IN_PROGRESS,
+            EnumAdviceTask.PLANTING_AND_HARVEST to EnumStepStatus.NOT_STARTED
+        )
+
+        tasks.forEach { (task, status) ->
+            viewModel.updateStatus(AdviceCompletionDto(taskName = task, stepStatus = status))
+        }
+        advanceUntilIdle()
+
+        tasks.forEach { (task, status) ->
+            coVerify { repo.updateStatus(AdviceCompletionDto(taskName = task, stepStatus = status)) }
+        }
+    }
+}

--- a/app/src/test/java/com/akilimo/mobile/ui/viewmodels/FertilizerViewModelTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/ui/viewmodels/FertilizerViewModelTest.kt
@@ -1,0 +1,151 @@
+package com.akilimo.mobile.ui.viewmodels
+
+import com.akilimo.mobile.entities.AkilimoUser
+import com.akilimo.mobile.entities.SelectedFertilizer
+import com.akilimo.mobile.enums.EnumCountry
+import com.akilimo.mobile.enums.EnumFertilizerFlow
+import com.akilimo.mobile.enums.EnumStepStatus
+import com.akilimo.mobile.repos.AkilimoUserRepo
+import com.akilimo.mobile.repos.FertilizerPriceRepo
+import com.akilimo.mobile.repos.FertilizerRepo
+import com.akilimo.mobile.repos.SelectedFertilizerRepo
+import com.akilimo.mobile.rules.TestDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class FertilizerViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = TestDispatcherRule()
+
+    private val fertilizerRepo: FertilizerRepo = mockk(relaxed = true)
+    private val selectedRepo: SelectedFertilizerRepo = mockk(relaxed = true)
+    private val userRepo: AkilimoUserRepo = mockk(relaxed = true)
+    private val priceRepo: FertilizerPriceRepo = mockk(relaxed = true)
+
+    private val testUser = AkilimoUser(id = 42, userName = "user1", enumCountry = EnumCountry.NG)
+
+    private fun buildViewModel(flow: EnumFertilizerFlow = EnumFertilizerFlow.DEFAULT): FertilizerViewModel {
+        coEvery { userRepo.getUser("user1") } returns testUser
+        every { fertilizerRepo.observeByCountry(EnumCountry.NG) } returns flowOf(emptyList())
+        every { fertilizerRepo.observeByCimAvailable(EnumCountry.NG) } returns flowOf(emptyList())
+        every { fertilizerRepo.observeByCisAvailable(EnumCountry.NG) } returns flowOf(emptyList())
+        coEvery { selectedRepo.getSelectedSync(42) } returns emptyList()
+        every { selectedRepo.observeSelected(42) } returns flowOf(emptyList())
+        return FertilizerViewModel(fertilizerRepo, selectedRepo, userRepo, priceRepo, "user1", flow)
+    }
+
+    @Before
+    fun setUp() {
+        // intentionally empty — each test builds its own ViewModel to control mock state
+    }
+
+    @Test
+    fun `getStepStatus returns COMPLETED when fertilizers are selected`() = runTest {
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        coEvery { selectedRepo.getSelectedSync(42) } returns listOf(
+            SelectedFertilizer(userId = 42, fertilizerId = 1, fertilizerPriceId = null)
+        )
+
+        assertEquals(EnumStepStatus.COMPLETED, viewModel.getStepStatus())
+    }
+
+    @Test
+    fun `getStepStatus returns IN_PROGRESS when no fertilizers are selected`() = runTest {
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        coEvery { selectedRepo.getSelectedSync(42) } returns emptyList()
+
+        assertEquals(EnumStepStatus.IN_PROGRESS, viewModel.getStepStatus())
+    }
+
+    @Test
+    fun `selectFertilizer delegates to selectedRepo with correct values`() = runTest {
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        viewModel.selectFertilizer(
+            fertilizerId = 7,
+            fertilizerPriceId = 3,
+            price = 120.0,
+            displayPrice = "120 NGN",
+            isExactPrice = true
+        )
+        advanceUntilIdle()
+
+        coVerify {
+            selectedRepo.select(match { sf ->
+                sf.userId == 42 &&
+                        sf.fertilizerId == 7 &&
+                        sf.fertilizerPriceId == 3 &&
+                        sf.fertilizerPrice == 120.0 &&
+                        sf.displayPrice == "120 NGN" &&
+                        sf.isExactPrice
+            })
+        }
+    }
+
+    @Test
+    fun `selectFertilizer uses 0 when price is null`() = runTest {
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        viewModel.selectFertilizer(
+            fertilizerId = 7,
+            fertilizerPriceId = null,
+            price = null,
+            displayPrice = null,
+            isExactPrice = false
+        )
+        advanceUntilIdle()
+
+        coVerify { selectedRepo.select(match { it.fertilizerPrice == 0.0 }) }
+    }
+
+    @Test
+    fun `deselectFertilizer delegates to selectedRepo`() = runTest {
+        val viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        viewModel.deselectFertilizer(7)
+        advanceUntilIdle()
+
+        coVerify { selectedRepo.deselect(42, 7) }
+    }
+
+    @Test
+    fun `DEFAULT flow observes fertilizers by country`() = runTest {
+        buildViewModel(EnumFertilizerFlow.DEFAULT)
+        advanceUntilIdle()
+
+        coVerify { fertilizerRepo.observeByCountry(EnumCountry.NG) }
+    }
+
+    @Test
+    fun `CIM flow observes CIM-available fertilizers`() = runTest {
+        buildViewModel(EnumFertilizerFlow.CIM)
+        advanceUntilIdle()
+
+        coVerify { fertilizerRepo.observeByCimAvailable(EnumCountry.NG) }
+    }
+
+    @Test
+    fun `CIS flow observes CIS-available fertilizers`() = runTest {
+        buildViewModel(EnumFertilizerFlow.CIS)
+        advanceUntilIdle()
+
+        coVerify { fertilizerRepo.observeByCisAvailable(EnumCountry.NG) }
+    }
+}

--- a/app/src/test/java/com/akilimo/mobile/ui/viewmodels/RecommendationsViewModelTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/ui/viewmodels/RecommendationsViewModelTest.kt
@@ -1,0 +1,118 @@
+package com.akilimo.mobile.ui.viewmodels
+
+import com.akilimo.mobile.entities.AkilimoUser
+import com.akilimo.mobile.enums.EnumAdvice
+import com.akilimo.mobile.enums.EnumCountry
+import com.akilimo.mobile.repos.AkilimoUserRepo
+import com.akilimo.mobile.rules.TestDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class RecommendationsViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = TestDispatcherRule()
+
+    private val userRepo: AkilimoUserRepo = mockk(relaxed = true)
+    private lateinit var viewModel: RecommendationsViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = RecommendationsViewModel(userRepo)
+    }
+
+    private fun userFor(country: EnumCountry) =
+        AkilimoUser(id = 1, userName = "user1", enumCountry = country)
+
+    @Test
+    fun `loadAdviceOptions for NG includes intercropping maize and not sweet potato`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns userFor(EnumCountry.NG)
+
+        viewModel.loadAdviceOptions("user1")
+        advanceUntilIdle()
+
+        val options = viewModel.uiState.value.adviceOptions.map { it.valueOption }
+        assertTrue(EnumAdvice.INTERCROPPING_MAIZE in options)
+        assertTrue(EnumAdvice.INTERCROPPING_SWEET_POTATO !in options)
+    }
+
+    @Test
+    fun `loadAdviceOptions for TZ includes intercropping sweet potato and not maize`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns userFor(EnumCountry.TZ)
+
+        viewModel.loadAdviceOptions("user1")
+        advanceUntilIdle()
+
+        val options = viewModel.uiState.value.adviceOptions.map { it.valueOption }
+        assertTrue(EnumAdvice.INTERCROPPING_SWEET_POTATO in options)
+        assertTrue(EnumAdvice.INTERCROPPING_MAIZE !in options)
+    }
+
+    @Test
+    fun `loadAdviceOptions for unsupported country has only 3 base options`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns userFor(EnumCountry.Unsupported)
+
+        viewModel.loadAdviceOptions("user1")
+        advanceUntilIdle()
+
+        val options = viewModel.uiState.value.adviceOptions
+        assertEquals(3, options.size)
+    }
+
+    @Test
+    fun `loadAdviceOptions always includes the 3 base recommendations`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns userFor(EnumCountry.NG)
+
+        viewModel.loadAdviceOptions("user1")
+        advanceUntilIdle()
+
+        val options = viewModel.uiState.value.adviceOptions.map { it.valueOption }
+        assertTrue(EnumAdvice.FERTILIZER_RECOMMENDATIONS in options)
+        assertTrue(EnumAdvice.BEST_PLANTING_PRACTICES in options)
+        assertTrue(EnumAdvice.SCHEDULED_PLANTING_HIGH_STARCH in options)
+    }
+
+    @Test
+    fun `loadAdviceOptions does nothing when user not found`() = runTest {
+        coEvery { userRepo.getUser("unknown") } returns null
+
+        viewModel.loadAdviceOptions("unknown")
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.adviceOptions.isEmpty())
+    }
+
+    @Test
+    fun `trackActiveAdvice saves selected advice on user`() = runTest {
+        val user = userFor(EnumCountry.NG)
+        coEvery { userRepo.getUser("user1") } returns user
+
+        viewModel.trackActiveAdvice("user1", EnumAdvice.FERTILIZER_RECOMMENDATIONS)
+        advanceUntilIdle()
+
+        coVerify {
+            userRepo.saveOrUpdateUser(
+                user.copy(activeAdvise = EnumAdvice.FERTILIZER_RECOMMENDATIONS),
+                "user1"
+            )
+        }
+    }
+
+    @Test
+    fun `trackActiveAdvice does nothing when user not found`() = runTest {
+        coEvery { userRepo.getUser("unknown") } returns null
+
+        viewModel.trackActiveAdvice("unknown", EnumAdvice.FERTILIZER_RECOMMENDATIONS)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { userRepo.saveOrUpdateUser(any(), any()) }
+    }
+}

--- a/app/src/test/java/com/akilimo/mobile/ui/viewmodels/TractorAccessViewModelTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/ui/viewmodels/TractorAccessViewModelTest.kt
@@ -1,0 +1,210 @@
+package com.akilimo.mobile.ui.viewmodels
+
+import com.akilimo.mobile.entities.AkilimoUser
+import com.akilimo.mobile.entities.FieldOperationCost
+import com.akilimo.mobile.enums.EnumAreaUnit
+import com.akilimo.mobile.enums.EnumCountry
+import com.akilimo.mobile.repos.AkilimoUserRepo
+import com.akilimo.mobile.repos.FieldOperationCostsRepo
+import com.akilimo.mobile.rules.TestDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class TractorAccessViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = TestDispatcherRule()
+
+    private val userRepo: AkilimoUserRepo = mockk(relaxed = true)
+    private val costsRepo: FieldOperationCostsRepo = mockk(relaxed = true)
+    private lateinit var viewModel: TractorAccessViewModel
+
+    private val testUser = AkilimoUser(
+        id = 1, userName = "user1",
+        enumCountry = EnumCountry.NG,
+        enumAreaUnit = EnumAreaUnit.ACRE,
+        farmSize = 2.0
+    )
+
+    @Before
+    fun setUp() {
+        viewModel = TractorAccessViewModel(userRepo, costsRepo)
+    }
+
+    @Test
+    fun `loadData populates uiState from user and existing costs`() = runTest {
+        val existingCost = FieldOperationCost(
+            userId = 1,
+            tractorAvailable = true,
+            tractorPloughCost = 50.0,
+            tractorRidgeCost = 30.0,
+            tractorHarrowCost = 20.0
+        )
+        coEvery { userRepo.getUser("user1") } returns testUser
+        coEvery { costsRepo.getCostForUser(1) } returns existingCost
+
+        viewModel.loadData("user1")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(1, state.userId)
+        assertEquals(2.0, state.farmSize, 0.0)
+        assertEquals(EnumAreaUnit.ACRE, state.enumAreaUnit)
+        assertTrue(state.tractorAvailable)
+        assertEquals(50.0, state.tractorPloughCost, 0.0)
+        assertEquals(30.0, state.tractorRidgeCost, 0.0)
+        assertEquals(20.0, state.tractorHarrowCost, 0.0)
+    }
+
+    @Test
+    fun `loadData uses defaults when no existing costs`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns testUser
+        coEvery { costsRepo.getCostForUser(1) } returns null
+
+        viewModel.loadData("user1")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.tractorAvailable)
+        assertEquals(0.0, state.tractorPloughCost, 0.0)
+    }
+
+    @Test
+    fun `saveCosts when tractorAvailable true preserves provided costs`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns testUser
+        coEvery { costsRepo.getCostForUser(1) } returns null
+        viewModel.loadData("user1")
+        advanceUntilIdle()
+
+        viewModel.saveCosts(
+            tractorAvailable = true,
+            ridingCost = 30.0,
+            ploughingCost = 50.0,
+            harrowingCost = 20.0
+        )
+        advanceUntilIdle()
+
+        coVerify {
+            costsRepo.saveCost(match { cost ->
+                cost.tractorAvailable &&
+                        cost.tractorRidgeCost == 30.0 &&
+                        cost.tractorPloughCost == 50.0 &&
+                        cost.tractorHarrowCost == 20.0
+            })
+        }
+    }
+
+    @Test
+    fun `saveCosts when tractorAvailable false zeroes all tractor costs`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns testUser
+        coEvery { costsRepo.getCostForUser(1) } returns null
+        viewModel.loadData("user1")
+        advanceUntilIdle()
+
+        viewModel.saveCosts(
+            tractorAvailable = false,
+            ridingCost = 100.0,
+            ploughingCost = 200.0,
+            harrowingCost = 300.0
+        )
+        advanceUntilIdle()
+
+        coVerify {
+            costsRepo.saveCost(match { cost ->
+                !cost.tractorAvailable &&
+                        cost.tractorRidgeCost == 0.0 &&
+                        cost.tractorPloughCost == 0.0 &&
+                        cost.tractorHarrowCost == 0.0
+            })
+        }
+    }
+
+    @Test
+    fun `saveCosts merges with existing costs preserving unspecified fields`() = runTest {
+        val existing = FieldOperationCost(
+            userId = 1,
+            manualPloughCost = 15.0,
+            tractorAvailable = true,
+            tractorPloughCost = 50.0,
+            tractorRidgeCost = 30.0,
+            tractorHarrowCost = 20.0
+        )
+        coEvery { userRepo.getUser("user1") } returns testUser
+        coEvery { costsRepo.getCostForUser(1) } returns existing
+        viewModel.loadData("user1")
+        advanceUntilIdle()
+
+        // Only update ploughing, leave others null
+        viewModel.saveCosts(
+            tractorAvailable = true,
+            ridingCost = null,
+            ploughingCost = 99.0,
+            harrowingCost = null
+        )
+        advanceUntilIdle()
+
+        coVerify {
+            costsRepo.saveCost(match { cost ->
+                cost.tractorPloughCost == 99.0 &&
+                        cost.tractorRidgeCost == 30.0 &&   // unchanged
+                        cost.tractorHarrowCost == 20.0 &&  // unchanged
+                        cost.manualPloughCost == 15.0       // manual cost preserved
+            })
+        }
+    }
+
+    @Test
+    fun `saveCosts sets saved flag`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns testUser
+        coEvery { costsRepo.getCostForUser(1) } returns null
+        viewModel.loadData("user1")
+        advanceUntilIdle()
+
+        viewModel.saveCosts(true, 10.0, 20.0, 30.0)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.saved)
+    }
+
+    @Test
+    fun `onSaveHandled resets saved flag`() = runTest {
+        coEvery { userRepo.getUser("user1") } returns testUser
+        coEvery { costsRepo.getCostForUser(1) } returns null
+        viewModel.loadData("user1")
+        advanceUntilIdle()
+        viewModel.saveCosts(true, 10.0, 20.0, 30.0)
+        advanceUntilIdle()
+
+        viewModel.onSaveHandled()
+
+        assertFalse(viewModel.uiState.value.saved)
+    }
+
+    @Test
+    fun `saveCosts does nothing when userId is 0`() = runTest {
+        // Do not call loadData — userId stays 0
+        viewModel.saveCosts(true, 10.0, 20.0, 30.0)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { costsRepo.saveCost(any()) }
+    }
+
+    @Test
+    fun `loadData does nothing when user not found`() = runTest {
+        coEvery { userRepo.getUser("unknown") } returns null
+
+        viewModel.loadData("unknown")
+        advanceUntilIdle()
+
+        assertEquals(0, viewModel.uiState.value.userId)
+    }
+}

--- a/app/src/test/java/com/akilimo/mobile/utils/MathHelperTest.kt
+++ b/app/src/test/java/com/akilimo/mobile/utils/MathHelperTest.kt
@@ -1,0 +1,62 @@
+package com.akilimo.mobile.utils
+
+import com.akilimo.mobile.enums.EnumAreaUnit
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MathHelperTest {
+
+    // ---- convertFromAcres ----
+
+    @Test
+    fun `convertFromAcres ACRE returns value unchanged`() {
+        assertEquals(2.5, MathHelper.convertFromAcres(2.5, EnumAreaUnit.ACRE), 0.0001)
+    }
+
+    @Test
+    fun `convertFromAcres HA applies correct factor`() {
+        // 1 acre = 0.404686 ha
+        assertEquals(0.404686, MathHelper.convertFromAcres(1.0, EnumAreaUnit.HA), 0.0001)
+    }
+
+    @Test
+    fun `convertFromAcres M2 applies correct factor`() {
+        // 1 acre = 4046.86 m²
+        assertEquals(4046.86, MathHelper.convertFromAcres(1.0, EnumAreaUnit.M2), 0.01)
+    }
+
+    @Test
+    fun `convertFromAcres ARE applies correct factor`() {
+        // 1 acre = 40.4686 ares
+        assertEquals(40.4686, MathHelper.convertFromAcres(1.0, EnumAreaUnit.ARE), 0.0001)
+    }
+
+    @Test
+    fun `convertFromAcres scales proportionally`() {
+        val single = MathHelper.convertFromAcres(1.0, EnumAreaUnit.HA)
+        val double = MathHelper.convertFromAcres(2.0, EnumAreaUnit.HA)
+        assertEquals(single * 2, double, 0.0001)
+    }
+
+    @Test
+    fun `convertFromAcres zero returns zero`() {
+        assertEquals(0.0, MathHelper.convertFromAcres(0.0, EnumAreaUnit.HA), 0.0)
+    }
+
+    // ---- format ----
+
+    @Test
+    fun `format whole number omits decimal places`() {
+        assertEquals("1,000", MathHelper.format(1000.0))
+    }
+
+    @Test
+    fun `format fractional number shows two decimal places`() {
+        assertEquals("1,000.50", MathHelper.format(1000.5))
+    }
+
+    @Test
+    fun `format zero returns zero without decimals`() {
+        assertEquals("0", MathHelper.format(0.0))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ detekt = "1.23.8"
 coroutines = "1.9.0"
 turbine = "1.2.0"
 mockk = "1.13.14"
+mockk-android = "1.13.14"
 
 debug-db = "v1.0.7"
 
@@ -94,6 +95,10 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk-android" }
+hilt-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
+navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigation" }
+room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 
 #rxjava = { group = "io.reactivex.rxjava2", name = "rxjava", version.ref = "rxjava" }
 #rxandroid = { group = "io.reactivex.rxjava2", name = "rxandroid", version.ref = "rxandroid" }


### PR DESCRIPTION
## Summary

- **Phase 1+2**: Convert 10 use-case Activities to Fragments. No-result screens (CassavaYield, InvestmentAmount, CassavaMarket) just save and pop back. Result-returning screens (Dates, WeedControlCosts, TractorAccess, ManualTillageCost) use the Fragment Result API to send back `AdviceCompletionDto`.
- **Phase 3+4**: Add `BaseFertilizerFragment` (mirrors `BaseFertilizerActivity`), fertilizer use-case Fragments (`FertilizersFragment`, `InterCropFertilizersFragment`, `SweetPotatoInterCropFertilizersFragment`), `GetRecommendationFragment`, and `UserSettingsFragment`. All use `childFragmentManager`, `viewLifecycleOwner`, and Fragment Result API as appropriate.
- **Phase 5**: Wire everything into the NavGraph. Replace `ActivityResult` launcher in `AbstractRecommendationFragment` with `findNavController().navigate()` + Fragment Result API listener. Add `AbstractProduceMarketFragment` base class; create `MaizeMarketFragment`, `SweetPotatoMarketFragment`, `MaizePerformanceFragment`. Update all 5 recommendation sub-fragments (`FrFragment`, `BppFragment`, `SphFragment`, `IcMaizeFragment`, `IcSweetPotatoFragment`) to use `mapTaskToDestination` instead of `mapTaskToIntent`. Expand `nav_recommendations.xml` with all 14 use-case destinations.

## Test plan

- [x] Launch app → tap through stepper → open Recommendations
- [x] Verify each recommendation use case (FR, BPP, SPH, IC Maize, IC Sweet Potato) opens correctly
- [x] Complete a use-case step (e.g. Fertilizers, Dates) and confirm step status updates in the list
- [x] Tap "Get Recommendation" button — verify `GetRecommendationFragment` loads with correct use case
- [x] Back navigation returns to the correct parent screen at each level
- [x] User Settings screen saves and applies language/dark mode changes
- [x] Maize Market, Sweet Potato Market, and Maize Performance screens save data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)