### PR TITLE
feat: pre-fill BPP screens from onboarding tillage selections

### DIFF
--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/TillageOperationFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/TillageOperationFragment.kt
@@ -16,6 +16,7 @@ import com.akilimo.mobile.dto.OperationMethodOption
 import com.akilimo.mobile.dto.OperationTypeOption
 import com.akilimo.mobile.dto.WeedControlOption
 import com.akilimo.mobile.entities.AkilimoUser
+import com.akilimo.mobile.entities.CurrentPractice
 import com.akilimo.mobile.enums.EnumOperationMethod
 import com.akilimo.mobile.enums.EnumOperationType
 import com.akilimo.mobile.enums.EnumWeedControlMethod
@@ -162,16 +163,41 @@ class TillageOperationFragment : BaseStepFragment<FragmentTillageOperationBindin
             return ValidationError(getString(R.string.lbl_select_tillage_method))
         }
 
+        val weedMethod = if (weedingRowBinding.checkboxOperation.isChecked) selectedWeedingMethod else null
+        val ploughingEntry = selectedEntries[EnumOperationType.PLOUGHING]
+        val ridgingEntry = selectedEntries[EnumOperationType.RIDGING]
+
         safeScope.launch {
             val user = onboardingViewModel.getUser(sessionManager.akilimoUser)
                 ?: AkilimoUser(userName = sessionManager.akilimoUser)
+            val userId = user.id
+
             onboardingViewModel.saveUser(
                 user.copy(
                     tillageOperations = selectedEntries.values.toList(),
-                    weedControlMethod = if (weedingRowBinding.checkboxOperation.isChecked) selectedWeedingMethod else null
+                    weedControlMethod = weedMethod
                 ),
                 sessionManager.akilimoUser
             )
+
+            if (userId != null) {
+                val existing = onboardingViewModel.getCurrentPractice(userId)
+                val updated = existing?.copy(
+                    performPloughing = ploughingEntry != null,
+                    ploughingMethod = ploughingEntry?.method?.valueOption?.name,
+                    performRidging = ridgingEntry != null,
+                    ridgingMethod = ridgingEntry?.method?.valueOption?.name,
+                    weedControlMethod = weedMethod ?: existing.weedControlMethod
+                ) ?: CurrentPractice(
+                    userId = userId,
+                    performPloughing = ploughingEntry != null,
+                    ploughingMethod = ploughingEntry?.method?.valueOption?.name,
+                    performRidging = ridgingEntry != null,
+                    ridgingMethod = ridgingEntry?.method?.valueOption?.name,
+                    weedControlMethod = weedMethod
+                )
+                onboardingViewModel.saveCurrentPractice(updated)
+            }
         }
 
         return null

--- a/app/src/main/java/com/akilimo/mobile/ui/viewmodels/OnboardingViewModel.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/viewmodels/OnboardingViewModel.kt
@@ -2,8 +2,10 @@ package com.akilimo.mobile.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
 import com.akilimo.mobile.entities.AkilimoUser
+import com.akilimo.mobile.entities.CurrentPractice
 import com.akilimo.mobile.entities.UserPreferences
 import com.akilimo.mobile.repos.AkilimoUserRepo
+import com.akilimo.mobile.repos.CurrentPracticeRepo
 import com.akilimo.mobile.repos.SelectedFertilizerRepo
 import com.akilimo.mobile.repos.UserPreferencesRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,7 +15,8 @@ import javax.inject.Inject
 class OnboardingViewModel @Inject constructor(
     private val userRepo: AkilimoUserRepo,
     private val prefsRepo: UserPreferencesRepo,
-    private val selectedFertilizerRepo: SelectedFertilizerRepo
+    private val selectedFertilizerRepo: SelectedFertilizerRepo,
+    private val currentPracticeRepo: CurrentPracticeRepo
 ) : ViewModel() {
 
     suspend fun getUser(userName: String): AkilimoUser? = userRepo.getUser(userName)
@@ -25,4 +28,10 @@ class OnboardingViewModel @Inject constructor(
 
     suspend fun deleteSelectedFertilizersByUser(userId: Int) =
         selectedFertilizerRepo.deleteByUserId(userId)
+
+    suspend fun saveCurrentPractice(practice: CurrentPractice) =
+        currentPracticeRepo.savePractice(practice)
+
+    suspend fun getCurrentPractice(userId: Int): CurrentPractice? =
+        currentPracticeRepo.getPracticeForUser(userId)
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/viewmodels/TractorAccessViewModel.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/viewmodels/TractorAccessViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.akilimo.mobile.entities.FieldOperationCost
 import com.akilimo.mobile.enums.EnumAreaUnit
+import com.akilimo.mobile.enums.EnumOperationMethod
 import com.akilimo.mobile.repos.AkilimoUserRepo
 import com.akilimo.mobile.repos.FieldOperationCostsRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -38,12 +39,19 @@ class TractorAccessViewModel @Inject constructor(
         val user = userRepo.getUser(userName) ?: return@launch
         val userId = user.id ?: return@launch
         val cost = costsRepo.getCostForUser(userId)
+
+        // Pre-fill tractorAvailable from onboarding if not yet set in BPP
+        val tractorFromOnboarding = user.tillageOperations.any {
+            it.method.valueOption == EnumOperationMethod.TRACTOR
+        }
+        val tractorAvailable = cost?.tractorAvailable ?: tractorFromOnboarding
+
         _uiState.update {
             it.copy(
                 userId = userId,
                 farmSize = user.farmSize,
                 enumAreaUnit = user.enumAreaUnit,
-                tractorAvailable = cost?.tractorAvailable ?: false,
+                tractorAvailable = tractorAvailable,
                 tractorPloughCost = cost?.tractorPloughCost ?: 0.0,
                 tractorRidgeCost = cost?.tractorRidgeCost ?: 0.0,
                 tractorHarrowCost = cost?.tractorHarrowCost ?: 0.0


### PR DESCRIPTION
## Summary

- **`TillageOperationFragment`**: On completing the onboarding tillage step, now also writes `performPloughing`, `ploughingMethod`, `performRidging`, `ridgingMethod`, and `weedControlMethod` to `CurrentPractice` — so `RecommendationBuilder` has the correct values even before the user touches any BPP screen
- **`OnboardingViewModel`**: Injects `CurrentPracticeRepo` and exposes `saveCurrentPractice()` / `getCurrentPractice()` to support the above
- **`TractorAccessViewModel`**: Pre-fills `tractorAvailable = true` when `AkilimoUser.tillageOperations` shows the user selected TRACTOR in onboarding (falls back gracefully if BPP has already been completed)

## Context

Addresses user feedback: *"Should these questions not match those of the entrance questions? To enable the comparison of current and recommended practice?"*

Previously, onboarding tillage selections were saved only to `AkilimoUser` and never propagated to `CurrentPractice`. This meant the BPP screens started blank even when the user had already provided the same information during onboarding.

## Data flow after this PR

| Onboarding action | Saved to | BPP reads from |
|---|---|---|
| Ploughing selected + method | `AkilimoUser.tillageOperations` + `CurrentPractice.performPloughing/ploughingMethod` | `RecommendationBuilder` via `CurrentPractice` |
| Ridging selected + method | same pattern | same |
| TRACTOR selected for any operation | `AkilimoUser.tillageOperations` | `TractorAccessViewModel` pre-fills toggle |
| Weeding method selected | `AkilimoUser.weedControlMethod` + `CurrentPractice.weedControlMethod` | `WeedControlCostsFragment` pre-fills dropdown |

## Test plan

- [x] Complete onboarding tillage step with PLOUGHING (TRACTOR) + RIDGING (MANUAL) + WEEDING (Herbicide)
- [x] Navigate to BPP → Tractor Access: verify tractor toggle is pre-selected
- [x] Navigate to BPP → Weed Control Costs: verify herbicide is pre-selected in dropdown
- [x] Skip all BPP screens and get recommendation: verify `RecommendationBuilder` sends correct `operationsDone` and `methods` values
- [x] Complete a BPP screen (e.g. save weed control costs with a different method): verify the BPP value overrides onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)