### PR TITLE
feat: context-aware BPP screens and onboarding step status pre-fill

### DIFF
--- a/app/src/main/java/com/akilimo/mobile/repos/AdviceCompletionRepo.kt
+++ b/app/src/main/java/com/akilimo/mobile/repos/AdviceCompletionRepo.kt
@@ -4,6 +4,7 @@ import com.akilimo.mobile.dao.AdviceCompletionDao
 import com.akilimo.mobile.entities.AdviceCompletion
 import com.akilimo.mobile.entities.AdviceCompletionDto
 import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.enums.EnumStepStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.util.Date
@@ -25,5 +26,12 @@ class AdviceCompletionRepo(private val dao: AdviceCompletionDao) {
 
     suspend fun clearCompleted(task: EnumAdviceTask) {
         dao.delete(task)
+    }
+
+    suspend fun markInProgressIfNotCompleted(task: EnumAdviceTask) {
+        val existing = dao.getAdviceByTask(task)
+        if (existing?.stepStatus != EnumStepStatus.COMPLETED) {
+            dao.upsert(AdviceCompletion(taskName = task, stepStatus = EnumStepStatus.IN_PROGRESS))
+        }
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/TillageOperationFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/TillageOperationFragment.kt
@@ -17,6 +17,7 @@ import com.akilimo.mobile.dto.OperationTypeOption
 import com.akilimo.mobile.dto.WeedControlOption
 import com.akilimo.mobile.entities.AkilimoUser
 import com.akilimo.mobile.entities.CurrentPractice
+import com.akilimo.mobile.enums.EnumAdviceTask
 import com.akilimo.mobile.enums.EnumOperationMethod
 import com.akilimo.mobile.enums.EnumOperationType
 import com.akilimo.mobile.enums.EnumWeedControlMethod
@@ -197,6 +198,12 @@ class TillageOperationFragment : BaseStepFragment<FragmentTillageOperationBindin
                     weedControlMethod = weedMethod
                 )
                 onboardingViewModel.saveCurrentPractice(updated)
+
+                val hasManual = selectedEntries.values.any { it.method.valueOption == EnumOperationMethod.MANUAL }
+                val hasTractor = selectedEntries.values.any { it.method.valueOption == EnumOperationMethod.TRACTOR }
+                if (hasManual) onboardingViewModel.markStepInProgress(EnumAdviceTask.MANUAL_TILLAGE_COST)
+                if (hasTractor) onboardingViewModel.markStepInProgress(EnumAdviceTask.TRACTOR_ACCESS)
+                if (weedMethod != null) onboardingViewModel.markStepInProgress(EnumAdviceTask.COST_OF_WEED_CONTROL)
             }
         }
 

--- a/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/ManualTillageCostFragment.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/fragments/usecases/ManualTillageCostFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -32,9 +33,10 @@ class ManualTillageCostFragment : BaseFragment<ActivityManualTillageCostBinding>
     override fun onBindingReady(savedInstanceState: Bundle?) {
         binding.apply {
             lytFabButton.fabSave.setOnClickListener {
+                val state = viewModel.uiState.value
                 viewModel.saveCosts(
-                    etRidingCost.text?.toString()?.toDoubleOrNull(),
-                    etPloughingCost.text?.toString()?.toDoubleOrNull()
+                    if (state.performRidging) etRidingCost.text?.toString()?.toDoubleOrNull() else null,
+                    if (state.performPloughing) etPloughingCost.text?.toString()?.toDoubleOrNull() else null
                 )
             }
             etPloughingCost.addTextChangedListener { toggleFab() }
@@ -65,12 +67,21 @@ class ManualTillageCostFragment : BaseFragment<ActivityManualTillageCostBinding>
 
                     val sizeUnitLabel = state.enumAreaUnit.label(requireContext()).orEmpty()
                     binding.apply {
-                        tvManualPlough.text = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_tillage_cost, state.farmSize, sizeUnitLabel) } }
-                        tilPloughingCost.hint = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_tillage_cost_hint, state.farmSize, sizeUnitLabel) } }
-                        tvManualRidge.text = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_ridge_cost, state.farmSize, sizeUnitLabel) } }
-                        tilRidgingCost.hint = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_ridge_cost_hint, state.farmSize, sizeUnitLabel) } }
-                        if (state.manualRidgeCost != null && etRidingCost.text.isNullOrEmpty()) etRidingCost.setText(state.manualRidgeCost.toString())
-                        if (state.manualPloughCost != null && etPloughingCost.text.isNullOrEmpty()) etPloughingCost.setText(state.manualPloughCost.toString())
+                        tvManualRidge.isVisible = state.performRidging
+                        tilRidgingCost.isVisible = state.performRidging
+                        tvManualPlough.isVisible = state.performPloughing
+                        tilPloughingCost.isVisible = state.performPloughing
+
+                        if (state.performPloughing) {
+                            tvManualPlough.text = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_tillage_cost, state.farmSize, sizeUnitLabel) } }
+                            tilPloughingCost.hint = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_tillage_cost_hint, state.farmSize, sizeUnitLabel) } }
+                            if (state.manualPloughCost != null && etPloughingCost.text.isNullOrEmpty()) etPloughingCost.setText(state.manualPloughCost.toString())
+                        }
+                        if (state.performRidging) {
+                            tvManualRidge.text = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_ridge_cost, state.farmSize, sizeUnitLabel) } }
+                            tilRidgingCost.hint = with(requireContext()) { StringHelper.run { formatWithLandSize(R.string.lbl_manual_ridge_cost_hint, state.farmSize, sizeUnitLabel) } }
+                            if (state.manualRidgeCost != null && etRidingCost.text.isNullOrEmpty()) etRidingCost.setText(state.manualRidgeCost.toString())
+                        }
                     }
                     toggleFab()
                 }
@@ -82,14 +93,16 @@ class ManualTillageCostFragment : BaseFragment<ActivityManualTillageCostBinding>
         val state = viewModel.uiState.value
         if (state.userId == 0) return false
         fun parse(text: CharSequence?) = text?.toString()?.toDoubleOrNull()?.takeIf { it >= 0 }
-        val plough = parse(binding.etPloughingCost.text)
-        val ridge = parse(binding.etRidingCost.text)
-        return (plough != null && plough != (state.manualPloughCost ?: 0.0)) ||
-               (ridge != null && ridge != (state.manualRidgeCost ?: 0.0))
+        val ploughChanged = state.performPloughing && parse(binding.etPloughingCost.text).let { it != null && it != (state.manualPloughCost ?: 0.0) }
+        val ridgeChanged = state.performRidging && parse(binding.etRidingCost.text).let { it != null && it != (state.manualRidgeCost ?: 0.0) }
+        return ploughChanged || ridgeChanged
     }
 
     private fun toggleFab() {
-        val show = viewModel.uiState.value.let { it.userId != 0 && (it.manualPloughCost == null || hasFormChanged()) }
+        val state = viewModel.uiState.value
+        val costMissing = (state.performPloughing && state.manualPloughCost == null) ||
+                          (state.performRidging && state.manualRidgeCost == null)
+        val show = state.userId != 0 && (costMissing || hasFormChanged())
         binding.lytFabButton.fabSave.apply { if (show) show() else hide() }
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/usecases/ManualTillageCostActivity.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/usecases/ManualTillageCostActivity.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.akilimo.mobile.R
 import com.akilimo.mobile.base.BaseActivity
 import com.akilimo.mobile.databinding.ActivityManualTillageCostBinding
+import androidx.core.view.isVisible
 import com.akilimo.mobile.entities.AdviceCompletionDto
 import com.akilimo.mobile.enums.EnumAdviceTask
 import com.akilimo.mobile.enums.EnumStepStatus
@@ -31,8 +32,9 @@ class ManualTillageCostActivity : BaseActivity<ActivityManualTillageCostBinding>
 
         binding.apply {
             lytFabButton.fabSave.setOnClickListener {
-                val ridingCost = etRidingCost.text?.toString()?.toDoubleOrNull()
-                val ploughingCost = etPloughingCost.text?.toString()?.toDoubleOrNull()
+                val state = viewModel.uiState.value
+                val ridingCost = if (state.performRidging) etRidingCost.text?.toString()?.toDoubleOrNull() else null
+                val ploughingCost = if (state.performPloughing) etPloughingCost.text?.toString()?.toDoubleOrNull() else null
                 viewModel.saveCosts(ridingCost, ploughingCost)
             }
             etPloughingCost.addTextChangedListener { toggleFab() }
@@ -62,24 +64,20 @@ class ManualTillageCostActivity : BaseActivity<ActivityManualTillageCostBinding>
 
                     val sizeUnitLabel = state.enumAreaUnit.label(this@ManualTillageCostActivity).orEmpty()
                     binding.apply {
-                        tvManualPlough.text = formatWithLandSize(
-                            R.string.lbl_manual_tillage_cost, state.farmSize, sizeUnitLabel
-                        )
-                        tilPloughingCost.hint = formatWithLandSize(
-                            R.string.lbl_manual_tillage_cost_hint, state.farmSize, sizeUnitLabel
-                        )
-                        tvManualRidge.text = formatWithLandSize(
-                            R.string.lbl_manual_ridge_cost, state.farmSize, sizeUnitLabel
-                        )
-                        tilRidgingCost.hint = formatWithLandSize(
-                            R.string.lbl_manual_ridge_cost_hint, state.farmSize, sizeUnitLabel
-                        )
+                        tvManualRidge.isVisible = state.performRidging
+                        tilRidgingCost.isVisible = state.performRidging
+                        tvManualPlough.isVisible = state.performPloughing
+                        tilPloughingCost.isVisible = state.performPloughing
 
-                        if (state.manualRidgeCost != null && etRidingCost.text.isNullOrEmpty()) {
-                            etRidingCost.setText(state.manualRidgeCost.toString())
+                        if (state.performPloughing) {
+                            tvManualPlough.text = formatWithLandSize(R.string.lbl_manual_tillage_cost, state.farmSize, sizeUnitLabel)
+                            tilPloughingCost.hint = formatWithLandSize(R.string.lbl_manual_tillage_cost_hint, state.farmSize, sizeUnitLabel)
+                            if (state.manualPloughCost != null && etPloughingCost.text.isNullOrEmpty()) etPloughingCost.setText(state.manualPloughCost.toString())
                         }
-                        if (state.manualPloughCost != null && etPloughingCost.text.isNullOrEmpty()) {
-                            etPloughingCost.setText(state.manualPloughCost.toString())
+                        if (state.performRidging) {
+                            tvManualRidge.text = formatWithLandSize(R.string.lbl_manual_ridge_cost, state.farmSize, sizeUnitLabel)
+                            tilRidgingCost.hint = formatWithLandSize(R.string.lbl_manual_ridge_cost_hint, state.farmSize, sizeUnitLabel)
+                            if (state.manualRidgeCost != null && etRidingCost.text.isNullOrEmpty()) etRidingCost.setText(state.manualRidgeCost.toString())
                         }
                     }
                     toggleFab()
@@ -100,14 +98,17 @@ class ManualTillageCostActivity : BaseActivity<ActivityManualTillageCostBinding>
         val ploughInput = parseNonNegativeDouble(binding.etPloughingCost.text)
         val ridgeInput = parseNonNegativeDouble(binding.etRidingCost.text)
 
-        val ploughChanged = ploughInput != null && ploughInput != (state.manualPloughCost ?: 0.0)
-        val ridgeChanged = ridgeInput != null && ridgeInput != (state.manualRidgeCost ?: 0.0)
+        val ploughChanged = state.performPloughing && ploughInput != null && ploughInput != (state.manualPloughCost ?: 0.0)
+        val ridgeChanged = state.performRidging && ridgeInput != null && ridgeInput != (state.manualRidgeCost ?: 0.0)
 
         return ploughChanged || ridgeChanged
     }
 
     private fun toggleFab() {
-        val shouldShow = viewModel.uiState.value.let { it.userId != 0 && (it.manualPloughCost == null || hasFormChanged()) }
+        val state = viewModel.uiState.value
+        val costMissing = (state.performPloughing && state.manualPloughCost == null) ||
+                          (state.performRidging && state.manualRidgeCost == null)
+        val shouldShow = state.userId != 0 && (costMissing || hasFormChanged())
         binding.lytFabButton.fabSave.apply {
             if (shouldShow) show() else hide()
         }

--- a/app/src/main/java/com/akilimo/mobile/ui/viewmodels/ManualTillageCostViewModel.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/viewmodels/ManualTillageCostViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.akilimo.mobile.entities.FieldOperationCost
 import com.akilimo.mobile.enums.EnumAreaUnit
 import com.akilimo.mobile.repos.AkilimoUserRepo
+import com.akilimo.mobile.repos.CurrentPracticeRepo
 import com.akilimo.mobile.repos.FieldOperationCostsRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -17,7 +18,8 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class ManualTillageCostViewModel @Inject constructor(
     private val userRepo: AkilimoUserRepo,
-    private val costsRepo: FieldOperationCostsRepo
+    private val costsRepo: FieldOperationCostsRepo,
+    private val currentPracticeRepo: CurrentPracticeRepo
 ) : ViewModel() {
 
     data class UiState(
@@ -26,6 +28,8 @@ class ManualTillageCostViewModel @Inject constructor(
         val enumAreaUnit: EnumAreaUnit = EnumAreaUnit.ACRE,
         val manualPloughCost: Double? = null,
         val manualRidgeCost: Double? = null,
+        val performPloughing: Boolean = true,
+        val performRidging: Boolean = true,
         val saved: Boolean = false
     )
 
@@ -36,13 +40,16 @@ class ManualTillageCostViewModel @Inject constructor(
         val user = userRepo.getUser(userName) ?: return@launch
         val userId = user.id ?: return@launch
         val cost = costsRepo.getCostForUser(userId)
+        val practice = currentPracticeRepo.getPracticeForUser(userId)
         _uiState.update {
             it.copy(
                 userId = userId,
                 farmSize = user.farmSize,
                 enumAreaUnit = user.enumAreaUnit,
                 manualPloughCost = cost?.manualPloughCost,
-                manualRidgeCost = cost?.manualRidgeCost
+                manualRidgeCost = cost?.manualRidgeCost,
+                performPloughing = practice?.performPloughing ?: true,
+                performRidging = practice?.performRidging ?: true
             )
         }
     }

--- a/app/src/main/java/com/akilimo/mobile/ui/viewmodels/OnboardingViewModel.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/viewmodels/OnboardingViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import com.akilimo.mobile.entities.AkilimoUser
 import com.akilimo.mobile.entities.CurrentPractice
 import com.akilimo.mobile.entities.UserPreferences
+import com.akilimo.mobile.enums.EnumAdviceTask
+import com.akilimo.mobile.repos.AdviceCompletionRepo
 import com.akilimo.mobile.repos.AkilimoUserRepo
 import com.akilimo.mobile.repos.CurrentPracticeRepo
 import com.akilimo.mobile.repos.SelectedFertilizerRepo
@@ -16,7 +18,8 @@ class OnboardingViewModel @Inject constructor(
     private val userRepo: AkilimoUserRepo,
     private val prefsRepo: UserPreferencesRepo,
     private val selectedFertilizerRepo: SelectedFertilizerRepo,
-    private val currentPracticeRepo: CurrentPracticeRepo
+    private val currentPracticeRepo: CurrentPracticeRepo,
+    private val adviceCompletionRepo: AdviceCompletionRepo
 ) : ViewModel() {
 
     suspend fun getUser(userName: String): AkilimoUser? = userRepo.getUser(userName)
@@ -34,4 +37,7 @@ class OnboardingViewModel @Inject constructor(
 
     suspend fun getCurrentPractice(userId: Int): CurrentPractice? =
         currentPracticeRepo.getPracticeForUser(userId)
+
+    suspend fun markStepInProgress(task: EnumAdviceTask) =
+        adviceCompletionRepo.markInProgressIfNotCompleted(task)
 }


### PR DESCRIPTION
## Summary

- **`ManualTillageCostFragment` + `ManualTillageCostActivity`**: Ploughing and ridging cost sections are now shown/hidden based on what the user opted into during onboarding. If the user said "no ploughing", the ploughing cost field is hidden and excluded from save/validation logic.
- **`ManualTillageCostViewModel`**: Loads `CurrentPractice` to expose `performPloughing`/`performRidging` flags in `UiState`.
- **`AdviceCompletionRepo`**: New `markInProgressIfNotCompleted()` — safely marks a step as `IN_PROGRESS` without downgrading already-`COMPLETED` steps.
- **`OnboardingViewModel`**: Injects `AdviceCompletionRepo` and exposes `markStepInProgress()`.
- **`TillageOperationFragment.verifyStep()`**: After writing to `CurrentPractice`, marks `MANUAL_TILLAGE_COST`, `TRACTOR_ACCESS`, and `COST_OF_WEED_CONTROL` as `IN_PROGRESS` on the BPP screen based on the user's onboarding selections — so step badges reflect pre-filled data without requiring the user to explicitly open each screen.

## Behaviour after this PR

| Onboarding selection | BPP effect |
|---|---|
| MANUAL ploughing or ridging | `Manual Tillage Cost` step badge → IN_PROGRESS; ploughing/ridging fields shown |
| TRACTOR ploughing or ridging | `Tractor Access` step badge → IN_PROGRESS; tractor toggle pre-checked |
| User opted out of ploughing | Ploughing cost field hidden in `ManualTillageCostFragment` |
| User opted out of ridging | Ridging cost field hidden |
| Weeding method selected | `Weed Control Costs` step badge → IN_PROGRESS; dropdown pre-filled |

## Test plan

- [x] Onboarding: select MANUAL ridging only (no ploughing) → BPP Manual Tillage Cost: only ridging field visible
- [x] Onboarding: select TRACTOR ploughing → BPP Tractor Access: tractor toggle pre-checked
- [x] BPP: complete Weed Control Costs (COMPLETED) → return to onboarding, change weeding method → verify step stays COMPLETED, not downgraded to IN_PROGRESS
- [x] Onboarding: no tillage selected → BPP Manual Tillage Cost: both fields hidden (edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)