### PR TITLE
Refine fertilizer selection screen UI

### DIFF
--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/FertilizerScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/FertilizerScreen.kt
@@ -1,8 +1,11 @@
 package com.akilimo.mobile.ui.screens.usecases
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,16 +14,22 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.ViewAgenda
+import androidx.compose.material.icons.filled.ViewModule
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -45,9 +54,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -62,6 +75,10 @@ import com.akilimo.mobile.enums.EnumStepStatus
 import com.akilimo.mobile.ui.components.compose.AkilimoTextField
 import com.akilimo.mobile.ui.viewmodels.FertilizerViewModel
 import kotlinx.coroutines.launch
+
+private val ScreenPadding = 16.dp
+private val ItemSpacing = 12.dp
+private val CardMinHeight = 148.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -112,10 +129,16 @@ fun FertilizerScreen(
                 actions = {
                     IconButton(onClick = { viewModel.toggleLayout() }) {
                         Icon(
-                            painter = painterResource(
-                                if (state.isGridLayout) R.drawable.ic_list else R.drawable.ic_grid
-                            ),
-                            contentDescription = null
+                            imageVector = if (state.isGridLayout) {
+                                Icons.Filled.ViewAgenda
+                            } else {
+                                Icons.Filled.ViewModule
+                            },
+                            contentDescription = if (state.isGridLayout) {
+                                stringResource(R.string.lbl_list)
+                            } else {
+                                stringResource(R.string.lbl_grid)
+                            }
                         )
                     }
                 }
@@ -136,41 +159,62 @@ fun FertilizerScreen(
                     enabled = state.selectedIds.isNotEmpty(),
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp)
+                        .padding(ScreenPadding)
+                        .height(52.dp)
                 ) {
                     Text(stringResource(R.string.lbl_finish))
                 }
             }
         }
     ) { padding ->
-        if (state.isGridLayout) {
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
-                contentPadding = padding,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = ScreenPadding)
+        ) {
+            FertilizerSelectionHeader(
+                selectedCount = state.selectedIds.size,
+                isGridLayout = state.isGridLayout,
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 8.dp)
-            ) {
-                items(state.fertilizers, key = { it.id ?: 0 }) { fertilizer ->
-                    FertilizerCard(
-                        fertilizer = fertilizer,
-                        isSelected = state.selectedIds.contains(fertilizer.id),
-                        onClick = { openSheet(fertilizer) },
-                        onDeselect = { fertilizer.id?.let { viewModel.deselectFertilizer(it) } }
-                    )
+                    .fillMaxWidth()
+                    .padding(top = ScreenPadding, bottom = ItemSpacing)
+            )
+
+            if (state.isGridLayout) {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    horizontalArrangement = Arrangement.spacedBy(ItemSpacing),
+                    verticalArrangement = Arrangement.spacedBy(ItemSpacing),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    items(state.fertilizers, key = { it.id ?: 0 }) { fertilizer ->
+                        FertilizerCard(
+                            fertilizer = fertilizer,
+                            isSelected = state.selectedIds.contains(fertilizer.id),
+                            isGridLayout = true,
+                            onClick = { openSheet(fertilizer) },
+                            onDeselect = { fertilizer.id?.let { viewModel.deselectFertilizer(it) } }
+                        )
+                    }
                 }
-            }
-        } else {
-            LazyColumn(contentPadding = padding) {
-                items(state.fertilizers, key = { it.id ?: 0 }) { fertilizer ->
-                    FertilizerCard(
-                        fertilizer = fertilizer,
-                        isSelected = state.selectedIds.contains(fertilizer.id),
-                        onClick = { openSheet(fertilizer) },
-                        onDeselect = { fertilizer.id?.let { viewModel.deselectFertilizer(it) } }
-                    )
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(ItemSpacing),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    items(state.fertilizers, key = { it.id ?: 0 }) { fertilizer ->
+                        FertilizerCard(
+                            fertilizer = fertilizer,
+                            isSelected = state.selectedIds.contains(fertilizer.id),
+                            isGridLayout = false,
+                            onClick = { openSheet(fertilizer) },
+                            onDeselect = { fertilizer.id?.let { viewModel.deselectFertilizer(it) } }
+                        )
+                    }
+                    item {
+                        Spacer(modifier = Modifier.height(ScreenPadding))
+                    }
                 }
             }
         }
@@ -188,8 +232,10 @@ fun FertilizerScreen(
         val selectedPriceItem = prices.find { it.id == selectedPriceId }
         val isExactSelected = selectedPriceItem?.pricePerBag?.let { it < 0.0 } == true
         val isConfirmEnabled = selectedPriceItem != null &&
-                (selectedPriceItem.pricePerBag > 0.0 ||
-                        (isExactSelected && exactPriceInput.toDoubleOrNull()?.let { it > 0.0 } == true))
+            (
+                selectedPriceItem.pricePerBag > 0.0 ||
+                    (isExactSelected && exactPriceInput.toDoubleOrNull()?.let { it > 0.0 } == true)
+                )
 
         ModalBottomSheet(
             onDismissRequest = { showPriceSheet = false },
@@ -198,14 +244,21 @@ fun FertilizerScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
+                    .padding(horizontal = ScreenPadding)
                     .verticalScroll(rememberScrollState())
             ) {
                 Text(
                     text = fert.name.orEmpty(),
-                    style = MaterialTheme.typography.titleMedium
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.lbl_select_price),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(ScreenPadding))
 
                 prices.forEach { price ->
                     val label = when {
@@ -213,32 +266,18 @@ fun FertilizerScreen(
                         price.pricePerBag < 0.0 -> stringResource(R.string.lbl_exact_price)
                         else -> price.priceRange
                     }
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { selectedPriceId = price.id }
-                    ) {
-                        RadioButton(
-                            selected = selectedPriceId == price.id,
-                            onClick = { selectedPriceId = price.id }
-                        )
-                        Text(label, modifier = Modifier.weight(1f))
-                    }
-                    if (price.pricePerBag < 0.0 && selectedPriceId == price.id) {
-                        AkilimoTextField(
-                            value = exactPriceInput,
-                            onValueChange = { exactPriceInput = it },
-                            label = stringResource(R.string.lbl_fertilizer_price),
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(start = 48.dp)
-                        )
-                    }
+                    FertilizerPriceOption(
+                        label = label,
+                        isSelected = selectedPriceId == price.id,
+                        showInput = price.pricePerBag < 0.0 && selectedPriceId == price.id,
+                        exactPriceInput = exactPriceInput,
+                        currencySymbol = price.currencySymbol.orEmpty(),
+                        onSelect = { selectedPriceId = price.id },
+                        onExactPriceChange = { exactPriceInput = it }
+                    )
                 }
 
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(ItemSpacing))
 
                 Button(
                     onClick = {
@@ -265,13 +304,15 @@ fun FertilizerScreen(
                         }
                     },
                     enabled = isConfirmEnabled,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(52.dp)
                 ) {
                     Text(stringResource(R.string.lbl_confirm))
                 }
 
                 if (state.selectedIds.contains(fert.id)) {
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(ItemSpacing))
                     OutlinedButton(
                         onClick = {
                             fert.id?.let { viewModel.deselectFertilizer(it) }
@@ -279,13 +320,121 @@ fun FertilizerScreen(
                                 showPriceSheet = false
                             }
                         },
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)
                     ) {
                         Text(stringResource(R.string.lbl_remove))
                     }
                 }
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(ScreenPadding))
+            }
+        }
+    }
+}
+
+@Composable
+private fun FertilizerSelectionHeader(
+    selectedCount: Int,
+    isGridLayout: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(ScreenPadding),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.lbl_choose_fertilizer),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+            Text(
+                text = if (selectedCount > 0) {
+                    "$selectedCount ${stringResource(R.string.lbl_selected)}"
+                } else {
+                    stringResource(R.string.lbl_tap_to_select_fertilizer)
+                },
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+            Text(
+                text = if (isGridLayout) {
+                    stringResource(R.string.lbl_grid_layout_hint)
+                } else {
+                    stringResource(R.string.lbl_list_layout_hint)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.9f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun FertilizerPriceOption(
+    label: String,
+    isSelected: Boolean,
+    showInput: Boolean,
+    exactPriceInput: String,
+    currencySymbol: String,
+    onSelect: () -> Unit,
+    onExactPriceChange: (String) -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp)
+            .clickable(onClick = onSelect),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isSelected) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surface
+            }
+        ),
+        border = BorderStroke(
+            width = if (isSelected) 2.dp else 1.dp,
+            color = if (isSelected) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.outlineVariant
+            }
+        )
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                RadioButton(
+                    selected = isSelected,
+                    onClick = onSelect
+                )
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            if (showInput) {
+                AkilimoTextField(
+                    value = exactPriceInput,
+                    onValueChange = onExactPriceChange,
+                    label = stringResource(R.string.lbl_fertilizer_price) +
+                        if (currencySymbol.isNotEmpty()) " ($currencySymbol)" else "",
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 48.dp, end = 8.dp, bottom = 4.dp)
+                )
             }
         }
     }
@@ -295,6 +444,7 @@ fun FertilizerScreen(
 private fun FertilizerCard(
     fertilizer: Fertilizer,
     isSelected: Boolean,
+    isGridLayout: Boolean,
     onClick: () -> Unit,
     onDeselect: () -> Unit
 ) {
@@ -303,41 +453,183 @@ private fun FertilizerCard(
             .fillMaxWidth()
             .clickable(onClick = if (isSelected) onDeselect else onClick),
         colors = CardDefaults.cardColors(
-            containerColor = if (isSelected)
+            containerColor = if (isSelected) {
                 MaterialTheme.colorScheme.primaryContainer
-            else
+            } else {
                 MaterialTheme.colorScheme.surface
+            }
+        ),
+        border = BorderStroke(
+            width = if (isSelected) 2.dp else 1.dp,
+            color = if (isSelected) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.outlineVariant
+            }
         )
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp)
-        ) {
-            Image(
-                painter = painterResource(R.drawable.ic_fertilizer_bag),
-                contentDescription = null,
-                colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(MaterialTheme.colorScheme.primary),
-                modifier = Modifier.size(64.dp)
+        if (isGridLayout) {
+            GridFertilizerCardContent(
+                fertilizer = fertilizer,
+                isSelected = isSelected
             )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = fertilizer.name.orEmpty(),
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = androidx.compose.ui.text.style.TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = if (isSelected && !fertilizer.displayPrice.isNullOrEmpty())
-                    fertilizer.displayPrice!!
-                else
-                    stringResource(R.string.under_score),
-                style = MaterialTheme.typography.bodySmall,
-                color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
-                        else MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+        } else {
+            ListFertilizerCardContent(
+                fertilizer = fertilizer,
+                isSelected = isSelected
             )
         }
+    }
+}
+
+@Composable
+private fun GridFertilizerCardContent(
+    fertilizer: Fertilizer,
+    isSelected: Boolean
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(CardMinHeight)
+            .padding(12.dp)
+    ) {
+        FertilizerIconBadge(isSelected = isSelected)
+        Text(
+            text = fertilizer.name.orEmpty(),
+            style = MaterialTheme.typography.bodyLarge,
+            color = if (isSelected) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+            textAlign = TextAlign.Center,
+            fontWeight = FontWeight.Medium
+        )
+        Text(
+            text = if (isSelected && !fertilizer.displayPrice.isNullOrEmpty()) {
+                fertilizer.displayPrice!!
+            } else {
+                stringResource(R.string.lbl_tap_to_add_price)
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (isSelected) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            textAlign = TextAlign.Center
+        )
+        if (isSelected) {
+            SelectedChip()
+        }
+    }
+}
+
+@Composable
+private fun ListFertilizerCardContent(
+    fertilizer: Fertilizer,
+    isSelected: Boolean
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(12.dp)
+    ) {
+        FertilizerIconBadge(isSelected = isSelected)
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = fertilizer.name.orEmpty(),
+                style = MaterialTheme.typography.titleMedium,
+                color = if (isSelected) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                }
+            )
+            Text(
+                text = if (isSelected && !fertilizer.displayPrice.isNullOrEmpty()) {
+                    fertilizer.displayPrice!!
+                } else {
+                    stringResource(R.string.lbl_tap_to_select_and_set_price)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (isSelected) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                }
+            )
+        }
+        if (isSelected) {
+            Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = stringResource(R.string.lbl_selected),
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun FertilizerIconBadge(isSelected: Boolean) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .clip(CircleShape)
+            .background(
+                if (isSelected) {
+                    MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.12f)
+                } else {
+                    MaterialTheme.colorScheme.primaryContainer
+                }
+            )
+            .padding(12.dp)
+    ) {
+        Image(
+            painter = painterResource(R.drawable.ic_fertilizer_bag),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(
+                if (isSelected) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.primary
+                }
+            ),
+            modifier = Modifier.size(40.dp)
+        )
+    }
+}
+
+@Composable
+private fun SelectedChip() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .clip(MaterialTheme.shapes.small)
+            .background(MaterialTheme.colorScheme.primary)
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Filled.CheckCircle,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.size(16.dp)
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = stringResource(R.string.lbl_selected),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.widthIn(min = 48.dp)
+        )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -720,4 +720,15 @@
     <string name="lbl_settings_saved">Settings saved successfully</string>
     <string name="lbl_select_language">Select language</string>
     <string name="lbl_select_area_unit">Select area unit</string>
+
+    <string name="lbl_list">List</string>
+    <string name="lbl_grid">Grid</string>
+    <string name="lbl_choose_fertilizer">Choose fertilizer</string>
+    <string name="lbl_selected">Selected</string>
+    <string name="lbl_tap_to_select_fertilizer">Tap a fertilizer to choose its price.</string>
+    <string name="lbl_grid_layout_hint">Grid view helps you compare options quickly.</string>
+    <string name="lbl_list_layout_hint">List view shows each option with more detail.</string>
+    <string name="lbl_tap_to_add_price">Tap to add price</string>
+    <string name="lbl_tap_to_select_and_set_price">Tap to select and set price</string>
+    <string name="lbl_select_price">Select the price that matches your area.</string>
 </resources>


### PR DESCRIPTION
### Motivation
- Improve clarity, legibility, and touch targets for the fertilizer selection flow to support outdoor use, low-end devices, and non-technical users. 
- Strengthen visual hierarchy and selection affordances so chosen fertilizers and price options are obvious at a glance. 
- Keep all existing state, business logic, and interactions unchanged while focusing only on layout and styling.

### Description
- Restructured `FertilizerScreen` into smaller reusable composables: `FertilizerSelectionHeader`, `FertilizerPriceOption`, `FertilizerCard` (with `GridFertilizerCardContent` / `ListFertilizerCardContent`), `FertilizerIconBadge`, and `SelectedChip` to improve readability and maintainability. 
- Visual and spacing updates: introduced `ScreenPadding`, `ItemSpacing`, `CardMinHeight`, consistent 8/12/16dp spacing, larger action heights (48–52dp), clearer borders for selected cards, and higher-contrast text colors via `MaterialTheme`. 
- Interaction and state preserved: did not change any ViewModels, state variables, selection logic, or networking; all confirm/remove/price flows and exact-price handling remain identical. 
- Added/updated resource strings used by the redesigned UI (`strings.xml`) for accessible labels and brief helper copy (layout hint, selection hints, price prompt, grid/list labels).

### Testing
- Ran `git diff --check` to validate whitespace/patch issues: passed. 
- Attempted `bash ./gradlew :app:compileDebugKotlin` to compile the app, but the Gradle wrapper failed to download the distribution in this environment due to a network/proxy error (HTTP 403), so a full build could not be completed here. 
- No runtime logic or unit tests were modified; UI-only refactor preserves all existing automated test surface.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1281ddb84832baf85954f44163ea5)