### PR TITLE
feat(ui): Material 3 redesign — parallax hero, collapsible top bars, onboarding progress

### DIFF
--- a/app/src/main/java/com/akilimo/mobile/enums/EnumAdvice.kt
+++ b/app/src/main/java/com/akilimo/mobile/enums/EnumAdvice.kt
@@ -4,15 +4,14 @@ import android.content.Context
 import com.akilimo.mobile.R
 import com.akilimo.mobile.interfaces.ILabelProvider
 
-enum class EnumAdvice(private val stringResId: Int) : ILabelProvider {
-    FERTILIZER_RECOMMENDATIONS(R.string.lbl_fertilizer_recommendations),
-    BEST_PLANTING_PRACTICES(R.string.lbl_best_planting_practices),
-    INTERCROPPING_MAIZE(R.string.lbl_intercropping_maize),
-    INTERCROPPING_SWEET_POTATO(R.string.lbl_intercropping_sweet_potato),
-    SCHEDULED_PLANTING_HIGH_STARCH(R.string.lbl_scheduled_planting_and_high_starch);
-//    WEED_MANAGEMENT(R.string.lbl_weed_management);
+enum class EnumAdvice(private val stringResId: Int, private val titleResId: Int) : ILabelProvider {
+    FERTILIZER_RECOMMENDATIONS(R.string.lbl_fertilizer_recommendations, R.string.lbl_fertilizer_rec),
+    BEST_PLANTING_PRACTICES(R.string.lbl_best_planting_practices, R.string.lbl_best_planting_practices_title),
+    INTERCROPPING_MAIZE(R.string.lbl_intercropping_maize, R.string.lbl_intercropping_maize_title),
+    INTERCROPPING_SWEET_POTATO(R.string.lbl_intercropping_sweet_potato, R.string.lbl_intercropping_sweet_potato_title),
+    SCHEDULED_PLANTING_HIGH_STARCH(R.string.lbl_scheduled_planting_and_high_starch, R.string.lbl_scheduled_planting_rec);
+//    WEED_MANAGEMENT(R.string.lbl_weed_management, R.string.lbl_weed_management);
 
-    override fun label(context: Context): String {
-        return context.getString(stringResId)
-    }
+    override fun label(context: Context): String = context.getString(stringResId)
+    fun title(context: Context): String = context.getString(titleResId)
 }

--- a/app/src/main/java/com/akilimo/mobile/repos/FertilizerRepo.kt
+++ b/app/src/main/java/com/akilimo/mobile/repos/FertilizerRepo.kt
@@ -30,14 +30,6 @@ class FertilizerRepo(private val dao: FertilizerDao) {
     fun observeByCountry(countryCode: EnumCountry): Flow<List<Fertilizer>> =
         dao.observeAllByCountry(countryCode)
 
-
-    @Deprecated("Need further evaluation if this is really useful now")
-    fun observeByCountryAndUseCase(
-        countryCode: EnumCountry,
-        useCase: EnumUseCase
-    ): Flow<List<Fertilizer>> =
-        dao.observeAllByCountryAndUseCase(countryCode, useCase)
-
     fun observeByCimAvailable(countryCode: EnumCountry): Flow<List<Fertilizer>> =
         dao.observeAllByCimAvailable(countryCode)
 

--- a/app/src/main/java/com/akilimo/mobile/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/activities/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.akilimo.mobile.ui.activities
 
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,6 +8,7 @@ import androidx.activity.enableEdgeToEdge
 import com.akilimo.mobile.navigation.AkilimoNavHost
 import com.akilimo.mobile.ui.theme.AkilimoTheme
 import dagger.hilt.android.AndroidEntryPoint
+import dev.b3nedikt.app_locale.AppLocale
 
 /**
  * Single-Activity host for the AKILIMO app.
@@ -17,6 +19,10 @@ import dagger.hilt.android.AndroidEntryPoint
  */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(AppLocale.wrap(newBase))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()

--- a/app/src/main/java/com/akilimo/mobile/ui/components/compose/BackTopAppBar.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/components/compose/BackTopAppBar.kt
@@ -1,5 +1,7 @@
 package com.akilimo.mobile.ui.components.compose
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.size
@@ -8,6 +10,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -15,6 +18,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -22,56 +27,129 @@ import com.akilimo.mobile.R
 
 /**
  * Enhanced TopAppBar with back navigation and subtitle support.
+ *
+ * When [collapsedTitle] and [scrollBehavior] are both provided, renders a
+ * [LargeTopAppBar] that crossfades between the full [title]/[subtitle] in the
+ * expanded state and [collapsedTitle] (a single short word) in the collapsed
+ * state. The caller must apply `Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)`
+ * to the enclosing Scaffold so the bar actually collapses on scroll.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BackTopAppBar(
     title: String,
     subtitle: String? = null,
+    collapsedTitle: String? = null,
     onBack: () -> Unit,
     actions: @Composable RowScope.() -> Unit = {},
     modifier: Modifier = Modifier,
-    scrollBehavior: TopAppBarScrollBehavior? = null
+    scrollBehavior: TopAppBarScrollBehavior? = null,
 ) {
-    TopAppBar(
-        title = {
-            Column {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                subtitle?.let {
+    val navIcon: @Composable () -> Unit = {
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier.size(48.dp),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(R.string.lbl_back),
+                tint = MaterialTheme.colorScheme.onPrimary,
+            )
+        }
+    }
+
+    if (collapsedTitle != null && scrollBehavior != null) {
+        val fraction = scrollBehavior.state.collapsedFraction
+
+        LargeTopAppBar(
+            title = {
+                Box {
+                    // Expanded content: shrinks its reported height to 0 as bar collapses
+                    // so the Box never reserves invisible space in the collapsed state.
+                    Column(
+                        modifier = Modifier
+                            .graphicsLayer { alpha = 1f - fraction }
+                            .layout { measurable, constraints ->
+                                val placeable = measurable.measure(constraints)
+                                val height = (placeable.height * (1f - fraction))
+                                    .toInt()
+                                    .coerceAtLeast(0)
+                                layout(placeable.width, height) {
+                                    placeable.place(0, 0)
+                                }
+                            },
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        if (subtitle != null) {
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                    // Collapsed content: a single short word fades in as the bar collapses
                     Text(
-                        text = it,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
+                        text = collapsedTitle,
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onPrimary,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.graphicsLayer { alpha = fraction },
                     )
                 }
-            }
-        },
-        navigationIcon = {
-            IconButton(
-                onClick = onBack,
-                modifier = Modifier.size(48.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = stringResource(R.string.lbl_back),
-                    tint = MaterialTheme.colorScheme.onPrimary
-                )
-            }
-        },
-        actions = actions,
-        modifier = modifier,
-        scrollBehavior = scrollBehavior,
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.primary,
-            scrolledContainerColor = MaterialTheme.colorScheme.primaryContainer,
+            },
+            navigationIcon = navIcon,
+            actions = actions,
+            modifier = modifier,
+            scrollBehavior = scrollBehavior,
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                scrolledContainerColor = MaterialTheme.colorScheme.primary,
+                titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
         )
-    )
+    } else {
+        TopAppBar(
+            title = {
+                Column {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (subtitle != null) {
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            },
+            navigationIcon = navIcon,
+            actions = actions,
+            modifier = modifier,
+            scrollBehavior = scrollBehavior,
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                scrolledContainerColor = MaterialTheme.colorScheme.primaryContainer,
+            ),
+        )
+    }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/components/compose/BrandHeader.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/components/compose/BrandHeader.kt
@@ -1,0 +1,82 @@
+package com.akilimo.mobile.ui.components.compose
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.akilimo.mobile.R
+import com.akilimo.mobile.ui.theme.AkilimoSpacing
+
+/**
+ * Full-width gradient brand hero block.
+ *
+ * Renders the AKILIMO logo on a primary-colored background with a subtle
+ * top-to-transparent dark overlay for visual depth. Accepts optional title
+ * and subtitle text. Use at the top of key screens (Welcome, Recommendations)
+ * to provide consistent visual anchoring.
+ */
+@Composable
+fun BrandHeader(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    subtitle: String? = null,
+) {
+    val depthOverlay = Brush.verticalGradient(
+        colors = listOf(Color.Black.copy(alpha = 0.12f), Color.Transparent),
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = MaterialTheme.colorScheme.primary)
+            .background(brush = depthOverlay)
+            .padding(vertical = AkilimoSpacing.xl, horizontal = AkilimoSpacing.md),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(AkilimoSpacing.xs),
+        ) {
+            Image(
+                painter = painterResource(R.drawable.ic_akilimo_logo_white),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimary),
+                modifier = Modifier.size(72.dp),
+            )
+            if (title != null) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            if (subtitle != null) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.85f),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = AkilimoSpacing.sm),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/akilimo/mobile/ui/components/compose/WizardBottomBar.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/components/compose/WizardBottomBar.kt
@@ -2,8 +2,10 @@ package com.akilimo.mobile.ui.components.compose
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -15,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.akilimo.mobile.R
+import com.akilimo.mobile.ui.theme.AkilimoSpacing
 
 @Composable
 fun WizardBottomBar(
@@ -35,20 +38,20 @@ fun WizardBottomBar(
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .padding(horizontal = AkilimoSpacing.md, vertical = AkilimoSpacing.xs),
         ) {
             if (!isFirstStep) {
                 TextButton(onClick = onBack) {
                     Text(stringResource(R.string.lbl_back))
                 }
             } else {
-                // Spacer to keep counter centred
-                Text("", modifier = Modifier.padding(horizontal = 16.dp))
+                Spacer(modifier = Modifier.width(64.dp))
             }
 
             Text(
                 text = "${currentStep + 1} / $totalSteps",
-                style = MaterialTheme.typography.bodySmall,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             Button(onClick = onNext) {

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/onboarding/OnboardingScreen.kt
@@ -1,5 +1,7 @@
 package com.akilimo.mobile.ui.screens.onboarding
 
+import android.app.Activity
+import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.animation.AnimatedContent
@@ -92,6 +94,9 @@ fun OnboardingScreen(
                     AppCompatDelegate.setApplicationLocales(
                         LocaleListCompat.forLanguageTags(effect.languageTag),
                     )
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                        (context as? Activity)?.recreate()
+                    }
                 }
                 else -> Unit
             }

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/onboarding/OnboardingScreen.kt
@@ -3,15 +3,21 @@ package com.akilimo.mobile.ui.screens.onboarding
 import androidx.activity.compose.BackHandler
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,14 +28,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.core.os.LocaleListCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.akilimo.mobile.Locales
+import com.akilimo.mobile.R
 import com.akilimo.mobile.navigation.RecommendationsRoute
+import com.akilimo.mobile.ui.components.compose.BackTopAppBar
 import com.akilimo.mobile.ui.components.compose.ExitConfirmDialog
-import com.akilimo.mobile.ui.screens.settings.LocationResult
 import com.akilimo.mobile.ui.components.compose.WizardBottomBar
 import com.akilimo.mobile.ui.screens.onboarding.steps.AreaUnitStep
 import com.akilimo.mobile.ui.screens.onboarding.steps.BioDataStep
@@ -42,12 +50,14 @@ import com.akilimo.mobile.ui.screens.onboarding.steps.SummaryStep
 import com.akilimo.mobile.ui.screens.onboarding.steps.TermsStep
 import com.akilimo.mobile.ui.screens.onboarding.steps.TillageStep
 import com.akilimo.mobile.ui.screens.onboarding.steps.WelcomeStep
+import com.akilimo.mobile.ui.screens.settings.LocationResult
 import com.akilimo.mobile.ui.viewmodels.OnboardingViewModel
 import com.akilimo.mobile.wizard.OnboardingStep
 import dev.b3nedikt.app_locale.AppLocale
 import kotlinx.coroutines.flow.collectLatest
 import kotlin.system.exitProcess
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OnboardingScreen(
     navController: NavHostController,
@@ -56,6 +66,14 @@ fun OnboardingScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     var showExitDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
+
+    val stepProgress by animateFloatAsState(
+        targetValue = if (state.visibleSteps.isNotEmpty())
+            (state.currentStepIndex + 1f) / state.visibleSteps.size
+        else 0f,
+        animationSpec = tween(durationMillis = 300),
+        label = "OnboardingProgress",
+    )
 
     // Collect one-shot effects
     LaunchedEffect(Unit) {
@@ -112,13 +130,32 @@ fun OnboardingScreen(
     }
 
     if (state.isLoading) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
             CircularProgressIndicator()
         }
         return
     }
 
     Scaffold(
+        topBar = {
+            if (state.currentStep != OnboardingStep.WELCOME) {
+                Column {
+                    BackTopAppBar(
+                        title = stepTitle(state.currentStep),
+                        onBack = { viewModel.onEvent(OnboardingViewModel.Event.BackClicked) },
+                    )
+                    LinearProgressIndicator(
+                        progress = { stepProgress },
+                        modifier = Modifier.fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.primary,
+                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    )
+                }
+            }
+        },
         bottomBar = {
             WizardBottomBar(
                 currentStep = state.currentStepIndex,
@@ -214,3 +251,20 @@ fun OnboardingScreen(
         }
     }
 }
+
+@Composable
+private fun stepTitle(step: OnboardingStep): String = stringResource(
+    when (step) {
+        OnboardingStep.WELCOME -> R.string.welcome_title
+        OnboardingStep.DISCLAIMER -> R.string.lbl_disclaimer
+        OnboardingStep.TERMS -> R.string.lbl_terms
+        OnboardingStep.BIO_DATA -> R.string.lbl_self_intro
+        OnboardingStep.COUNTRY -> R.string.lbl_country
+        OnboardingStep.LOCATION -> R.string.lbl_location
+        OnboardingStep.AREA_UNIT -> R.string.lbl_field
+        OnboardingStep.PLANTING_DATE -> R.string.lbl_planting_harvest_dates
+        OnboardingStep.TILLAGE -> R.string.lbl_tillage_operation
+        OnboardingStep.INVESTMENT_PREF -> R.string.lbl_investment_pref_prompt
+        OnboardingStep.SUMMARY -> R.string.lbl_summary_title
+    }
+)

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/onboarding/steps/SummaryStep.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/onboarding/steps/SummaryStep.kt
@@ -4,21 +4,32 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.akilimo.mobile.R
+import com.akilimo.mobile.ui.theme.AkilimoSpacing
 import com.akilimo.mobile.ui.viewmodels.OnboardingViewModel
 import com.akilimo.mobile.utils.DateHelper
 
@@ -32,54 +43,110 @@ fun SummaryStep(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+            .verticalScroll(rememberScrollState()),
     ) {
-        Text(stringResource(R.string.lbl_summary_title), style = MaterialTheme.typography.headlineMedium)
-
-        SummarySection(title = stringResource(R.string.lbl_self_intro)) {
-            SummaryRow(stringResource(R.string.lbl_first_name), state.firstName)
-            SummaryRow(stringResource(R.string.lbl_last_name), state.lastName)
-            SummaryRow(stringResource(R.string.lbl_email_address), state.email)
-            SummaryRow(stringResource(R.string.lbl_phone_number), state.phone)
-            SummaryRow(stringResource(R.string.lbl_gender), state.gender)
-        }
-
-        SummarySection(title = stringResource(R.string.lbl_field)) {
-            SummaryRow(stringResource(R.string.lbl_country), state.country.countryName)
-            SummaryRow(stringResource(R.string.lbl_farm_size), "%.2f %s".format(state.farmSize, state.areaUnit.label(context)))
-            if (state.latitude != 0.0) {
-                SummaryRow(stringResource(R.string.lbl_location), "Lat: %.5f, Lng: %.5f".format(state.latitude, state.longitude))
+        // Completion header — full-width, no horizontal padding
+        Surface(
+            color = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(
+                modifier = Modifier.padding(AkilimoSpacing.md),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.CheckCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(40.dp),
+                )
+                Spacer(Modifier.width(AkilimoSpacing.md))
+                Text(
+                    text = stringResource(R.string.lbl_summary_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
             }
         }
 
-        SummarySection(title = stringResource(R.string.lbl_planting_harvest_dates)) {
-            SummaryRow(stringResource(R.string.lbl_planting_date), DateHelper.formatToString(state.plantingDate))
-            SummaryRow(stringResource(R.string.lbl_harvesting_date), DateHelper.formatToString(state.harvestDate))
-        }
-
-        SummarySection(title = stringResource(R.string.lbl_tillage_operations)) {
-            state.tillageOperations.forEach { (type, method) ->
-                SummaryRow(type.label(context), method.label(context))
+        // Section cards with horizontal padding
+        Column(
+            modifier = Modifier.padding(AkilimoSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(AkilimoSpacing.sm),
+        ) {
+            SummarySection(title = stringResource(R.string.lbl_self_intro)) {
+                SummaryRow(stringResource(R.string.lbl_first_name), state.firstName)
+                SummaryRow(stringResource(R.string.lbl_last_name), state.lastName)
+                SummaryRow(stringResource(R.string.lbl_email_address), state.email)
+                SummaryRow(stringResource(R.string.lbl_phone_number), state.phone)
+                SummaryRow(stringResource(R.string.lbl_gender), state.gender)
             }
-            state.weedControlMethod?.let { method ->
-                SummaryRow(stringResource(R.string.lbl_weeding), method.label(context))
-            }
-        }
 
-        SummarySection(title = stringResource(R.string.lbl_investment_pref)) {
-            SummaryRow(stringResource(R.string.lbl_investment_pref_prompt), state.investmentPref.label(context))
+            SummarySection(title = stringResource(R.string.lbl_field)) {
+                SummaryRow(stringResource(R.string.lbl_country), state.country.countryName)
+                SummaryRow(
+                    stringResource(R.string.lbl_farm_size),
+                    "%.2f %s".format(state.farmSize, state.areaUnit.label(context))
+                )
+                if (state.latitude != 0.0) {
+                    SummaryRow(
+                        stringResource(R.string.lbl_location),
+                        "Lat: %.5f, Lng: %.5f".format(state.latitude, state.longitude)
+                    )
+                }
+            }
+
+            SummarySection(title = stringResource(R.string.lbl_planting_harvest_dates)) {
+                SummaryRow(
+                    stringResource(R.string.lbl_planting_date),
+                    DateHelper.formatToString(state.plantingDate)
+                )
+                SummaryRow(
+                    stringResource(R.string.lbl_harvesting_date),
+                    DateHelper.formatToString(state.harvestDate)
+                )
+            }
+
+            SummarySection(title = stringResource(R.string.lbl_tillage_operations)) {
+                state.tillageOperations.forEach { (type, method) ->
+                    SummaryRow(type.label(context), method.label(context))
+                }
+                state.weedControlMethod?.let { method ->
+                    SummaryRow(stringResource(R.string.lbl_weeding), method.label(context))
+                }
+            }
+
+            SummarySection(title = stringResource(R.string.lbl_investment_pref)) {
+                SummaryRow(
+                    stringResource(R.string.lbl_investment_pref_prompt),
+                    state.investmentPref.label(context)
+                )
+            }
         }
     }
 }
 
 @Composable
 private fun SummarySection(title: String, content: @Composable ColumnScope.() -> Unit) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(title, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary)
-            HorizontalDivider()
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(AkilimoSpacing.sm),
+            verticalArrangement = Arrangement.spacedBy(AkilimoSpacing.xxs),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
             content()
         }
     }
@@ -88,9 +155,24 @@ private fun SummarySection(title: String, content: @Composable ColumnScope.() ->
 @Composable
 private fun SummaryRow(label: String, value: String?) {
     if (!value.isNullOrBlank()) {
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(label, style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
-            Text(value, style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = AkilimoSpacing.xxs),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(1f),
+            )
         }
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/onboarding/steps/WelcomeStep.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/onboarding/steps/WelcomeStep.kt
@@ -2,27 +2,24 @@ package com.akilimo.mobile.ui.screens.onboarding.steps
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Language
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.akilimo.mobile.Locales
 import com.akilimo.mobile.R
 import com.akilimo.mobile.ui.components.compose.AkilimoDropdown
+import com.akilimo.mobile.ui.components.compose.BrandHeader
 import com.akilimo.mobile.ui.components.compose.InfoCard
 import com.akilimo.mobile.ui.components.compose.InfoCardType
-import com.akilimo.mobile.ui.components.compose.SectionHeader
 import com.akilimo.mobile.ui.theme.AkilimoSpacing
 import com.akilimo.mobile.ui.viewmodels.OnboardingViewModel
+
 @Composable
 fun WelcomeStep(
     languageCode: String,
@@ -32,35 +29,37 @@ fun WelcomeStep(
     val locales = Locales.supportedLocales
     val selectedLocale = locales.find { it.toLanguageTag() == languageCode } ?: Locales.english
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(AkilimoSpacing.md),
-        verticalArrangement = Arrangement.spacedBy(AkilimoSpacing.md),
-    ) {
-        SectionHeader(
+    Column(modifier = modifier.fillMaxSize()) {
+        BrandHeader(
             title = stringResource(R.string.welcome_title),
-            subtitle = stringResource(R.string.welcome_subtitle)
-        )
-        
-        InfoCard(
-            title = stringResource(R.string.lbl_select_language),
-            message = stringResource(R.string.msg_language_selection_impact),
-            icon = Icons.Outlined.Language,
-            type = InfoCardType.Info
+            subtitle = stringResource(R.string.welcome_subtitle),
         )
 
-        Spacer(modifier = Modifier.height(AkilimoSpacing.xs))
-
-        AkilimoDropdown(
-            label = stringResource(R.string.lbl_language),
-            options = locales,
-            selectedOption = selectedLocale,
-            onOptionSelected = { locale ->
-                val tag = locale.toLanguageTag()
-                onEvent(OnboardingViewModel.Event.LanguageSelected(tag))
-            },
-            displayText = { locale -> locale.getDisplayLanguage(locale).replaceFirstChar { it.uppercaseChar() } },
-        )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(AkilimoSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(AkilimoSpacing.md),
+        ) {
+            InfoCard(
+                title = stringResource(R.string.lbl_select_language),
+                message = stringResource(R.string.msg_language_selection_impact),
+                icon = Icons.Outlined.Language,
+                type = InfoCardType.Info,
+            )
+            AkilimoDropdown(
+                label = stringResource(R.string.lbl_language),
+                options = locales,
+                selectedOption = selectedLocale,
+                onOptionSelected = { locale ->
+                    val tag = locale.toLanguageTag()
+                    onEvent(OnboardingViewModel.Event.LanguageSelected(tag))
+                },
+                displayText = { locale ->
+                    locale.getDisplayLanguage(locale).replaceFirstChar { it.uppercaseChar() }
+                },
+            )
+        }
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/recommendations/GetRecommendationScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/recommendations/GetRecommendationScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.akilimo.mobile.ui.theme.AkilimoSpacing
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.akilimo.mobile.R
@@ -93,11 +94,11 @@ fun GetRecommendationScreen(useCase: EnumUseCase, navController: NavHostControll
                     Column(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(16.dp)
+                            .padding(AkilimoSpacing.md)
                             .verticalScroll(rememberScrollState())
                     ) {
                         Text(text = title, style = MaterialTheme.typography.headlineSmall)
-                        Spacer(Modifier.height(12.dp))
+                        Spacer(Modifier.height(AkilimoSpacing.sm))
                         Text(text = s.description, style = MaterialTheme.typography.bodyMedium)
                     }
                 }
@@ -108,7 +109,7 @@ fun GetRecommendationScreen(useCase: EnumUseCase, navController: NavHostControll
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         Text(s.message, style = MaterialTheme.typography.bodyMedium)
-                        Spacer(Modifier.height(16.dp))
+                        Spacer(Modifier.height(AkilimoSpacing.md))
                         Button(
                             onClick = {
                                 viewModel.fetchRecommendation(useCase, noRecsLabel, errorLabel)

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/recommendations/RecommendationsScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/recommendations/RecommendationsScreen.kt
@@ -1,26 +1,54 @@
 package com.akilimo.mobile.ui.screens.recommendations
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.Eco
+import androidx.compose.material.icons.outlined.Grass
+import androidx.compose.material.icons.outlined.Science
+import androidx.compose.material.icons.outlined.Spa
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -33,7 +61,16 @@ import com.akilimo.mobile.navigation.FrRoute
 import com.akilimo.mobile.navigation.IcMaizeRoute
 import com.akilimo.mobile.navigation.IcSweetPotatoRoute
 import com.akilimo.mobile.navigation.SphRoute
+import com.akilimo.mobile.ui.theme.AkilimoSpacing
 import com.akilimo.mobile.ui.viewmodels.RecommendationsViewModel
+
+private fun EnumAdvice.icon(): ImageVector = when (this) {
+    EnumAdvice.FERTILIZER_RECOMMENDATIONS -> Icons.Outlined.Science
+    EnumAdvice.BEST_PLANTING_PRACTICES -> Icons.Outlined.Eco
+    EnumAdvice.INTERCROPPING_MAIZE -> Icons.Outlined.Grass
+    EnumAdvice.INTERCROPPING_SWEET_POTATO -> Icons.Outlined.Spa
+    EnumAdvice.SCHEDULED_PLANTING_HIGH_STARCH -> Icons.Outlined.CalendarMonth
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,12 +78,77 @@ fun RecommendationsScreen(navController: NavHostController) {
     val viewModel = hiltViewModel<RecommendationsViewModel>()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(title = { Text(stringResource(R.string.lbl_recommendations)) })
+    val listState = rememberLazyListState()
+    val heroPx = with(LocalDensity.current) { 240.dp.toPx() }
+
+    val scrollOffsetPx by remember {
+        derivedStateOf {
+            if (listState.firstVisibleItemIndex == 0)
+                listState.firstVisibleItemScrollOffset.toFloat()
+            else heroPx
         }
-    ) { padding ->
-        LazyColumn(contentPadding = padding) {
+    }
+    val appBarAlpha by remember {
+        derivedStateOf { (scrollOffsetPx / heroPx).coerceIn(0f, 1f) }
+    }
+    val heroContentAlpha by remember {
+        derivedStateOf { (1f - scrollOffsetPx / heroPx * 1.5f).coerceIn(0f, 1f) }
+    }
+    val parallaxOffsetPx by remember {
+        derivedStateOf { scrollOffsetPx * 0.35f }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .navigationBarsPadding(),
+        ) {
+            item(key = "hero") {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(240.dp)
+                        .background(MaterialTheme.colorScheme.primary)
+                        .background(
+                            Brush.verticalGradient(
+                                listOf(
+                                    Color.Black.copy(alpha = 0.3f),
+                                    Color.Transparent,
+                                    Color.Black.copy(alpha = 0.15f),
+                                )
+                            )
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(
+                        modifier = Modifier.graphicsLayer {
+                            translationY = -parallaxOffsetPx
+                            alpha = heroContentAlpha
+                        },
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(AkilimoSpacing.sm),
+                    ) {
+                        Image(
+                            painter = painterResource(R.drawable.ic_akilimo_logo_white),
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimary),
+                            modifier = Modifier.size(120.dp),
+                        )
+                        Text(
+                            text = stringResource(R.string.lbl_recommendations),
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    }
+                }
+            }
             items(state.adviceOptions) { option ->
                 AdviceOptionCard(
                     option = option,
@@ -64,6 +166,30 @@ fun RecommendationsScreen(navController: NavHostController) {
                 )
             }
         }
+
+        TopAppBar(
+            title = {
+                Text(
+                    text = stringResource(R.string.lbl_recommendations),
+                    modifier = Modifier.graphicsLayer { alpha = appBarAlpha },
+                )
+            },
+            navigationIcon = {
+                Image(
+                    painter = painterResource(R.drawable.ic_akilimo_logo_white),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimary),
+                    modifier = Modifier
+                        .padding(start = AkilimoSpacing.md)
+                        .size(AkilimoSpacing.xxl),
+                )
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.primary.copy(alpha = appBarAlpha),
+                titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+        )
     }
 }
 
@@ -71,22 +197,51 @@ fun RecommendationsScreen(navController: NavHostController) {
 private fun AdviceOptionCard(option: AdviceOption, onClick: () -> Unit) {
     val context = LocalContext.current
     Card(
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .clickable(onClick = onClick),
+            .padding(horizontal = AkilimoSpacing.md, vertical = AkilimoSpacing.xs),
         shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
     ) {
         Row(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AkilimoSpacing.md),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = option.valueOption.label(context),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.weight(1f),
+            Surface(
+                shape = MaterialTheme.shapes.small,
+                color = MaterialTheme.colorScheme.primaryContainer,
+                modifier = Modifier.size(AkilimoSpacing.xxxl),
+            ) {
+                Icon(
+                    imageVector = option.valueOption.icon(),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.padding(AkilimoSpacing.sm),
+                )
+            }
+            Spacer(Modifier.width(AkilimoSpacing.md))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = option.valueOption.title(context),
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = option.valueOption.label(context),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.width(AkilimoSpacing.xs))
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null)
         }
     }
 }

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/recommendations/TaskItemCard.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/recommendations/TaskItemCard.kt
@@ -1,46 +1,101 @@
 package com.akilimo.mobile.ui.screens.recommendations
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.AccessTime
-import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.akilimo.mobile.enums.EnumStepStatus
+import com.akilimo.mobile.ui.theme.AkilimoSpacing
 
 @Composable
-fun TaskItemCard(label: String, status: EnumStepStatus, onClick: () -> Unit) {
+fun TaskItemCard(
+    label: String,
+    status: EnumStepStatus,
+    onClick: () -> Unit,
+    stepNumber: Int = -1,
+) {
+    val isCompleted = status == EnumStepStatus.COMPLETED
     Card(
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 6.dp)
-            .clickable(onClick = onClick),
+            .padding(horizontal = AkilimoSpacing.md, vertical = AkilimoSpacing.xs),
         shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(
+            containerColor = if (isCompleted)
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+            else
+                MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (isCompleted) 0.dp else 1.dp),
     ) {
         Row(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AkilimoSpacing.md),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            if (stepNumber > 0) {
+                StepBadge(stepNumber = stepNumber, status = status)
+                Spacer(modifier = Modifier.width(AkilimoSpacing.md))
+            }
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = Modifier.weight(1f),
             )
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(AkilimoSpacing.xs))
             StatusBadge(status = status)
-            Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null)
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepBadge(stepNumber: Int, status: EnumStepStatus) {
+    val isCompleted = status == EnumStepStatus.COMPLETED
+    Surface(
+        shape = CircleShape,
+        color = if (isCompleted) MaterialTheme.colorScheme.primary
+        else MaterialTheme.colorScheme.surfaceVariant,
+        modifier = Modifier.size(AkilimoSpacing.xxl),
+    ) {
+        Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            if (isCompleted) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.padding(AkilimoSpacing.xxs),
+                )
+            } else {
+                Text(
+                    text = stepNumber.toString(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }
@@ -48,17 +103,11 @@ fun TaskItemCard(label: String, status: EnumStepStatus, onClick: () -> Unit) {
 @Composable
 private fun StatusBadge(status: EnumStepStatus) {
     when (status) {
-        EnumStepStatus.COMPLETED -> Icon(
-            imageVector = Icons.Default.CheckCircle,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(end = 8.dp),
-        )
         EnumStepStatus.IN_PROGRESS -> Icon(
             imageVector = Icons.Default.AccessTime,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.padding(end = 8.dp),
+            modifier = Modifier.padding(end = AkilimoSpacing.xs),
         )
         else -> Unit
     }

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/recommendations/UseCaseScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/recommendations/UseCaseScreen.kt
@@ -1,7 +1,7 @@
 package com.akilimo.mobile.ui.screens.recommendations
 
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -102,10 +102,11 @@ fun UseCaseScreen(
         }
     ) { padding ->
         LazyColumn(contentPadding = padding) {
-            items(taskItems, key = { it.first.name }) { (task, status) ->
+            itemsIndexed(taskItems, key = { _, item -> item.first.name }) { index, (task, status) ->
                 TaskItemCard(
                     label = task.label(context),
                     status = status,
+                    stepNumber = index + 1,
                     onClick = { navigateToTask(task) }
                 )
             }

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/settings/UserSettingsScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/settings/UserSettingsScreen.kt
@@ -1,5 +1,7 @@
 package com.akilimo.mobile.ui.screens.settings
 
+import android.app.Activity
+import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -130,6 +132,10 @@ fun UserSettingsScreen(navController: NavHostController) {
             AppCompatDelegate.setApplicationLocales(
                 LocaleListCompat.forLanguageTags(state.newLanguageCode)
             )
+            // setApplicationLocales only auto-recreates on API 33+; recreate manually below that.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                (context as? Activity)?.recreate()
+            }
         }
 
         viewModel.onSaveHandled()

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/settings/UserSettingsScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/settings/UserSettingsScreen.kt
@@ -1,19 +1,16 @@
 package com.akilimo.mobile.ui.screens.settings
 
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -24,7 +21,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -41,7 +37,9 @@ import com.akilimo.mobile.enums.EnumCountry
 import com.akilimo.mobile.ui.components.compose.AkilimoDropdown
 import com.akilimo.mobile.ui.components.compose.BackTopAppBar
 import com.akilimo.mobile.ui.components.compose.LabeledTextField
+import com.akilimo.mobile.ui.components.compose.SaveBottomBar
 import com.akilimo.mobile.ui.components.compose.SwitchRow
+import com.akilimo.mobile.ui.theme.AkilimoSpacing
 import com.akilimo.mobile.ui.viewmodels.UserSettingsViewModel
 import dev.b3nedikt.app_locale.AppLocale
 
@@ -147,12 +145,44 @@ fun UserSettingsScreen(navController: NavHostController) {
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
+        bottomBar = {
+            SaveBottomBar(
+                label = stringResource(R.string.lbl_save),
+                onClick = {
+                    val validEmail = android.util.Patterns.EMAIL_ADDRESS
+                    val validPhone = android.util.Patterns.PHONE
+                    if (email.isNotBlank() && !validEmail.matcher(email).matches()) {
+                        emailError = context.getString(R.string.lbl_valid_email_req)
+                    } else if (phone.isNotBlank() && !validPhone.matcher(phone).matches()) {
+                        phoneError = context.getString(R.string.lbl_valid_number_req)
+                    } else {
+                        val prefs = UserPreferences(
+                            languageCode = selectedLanguage?.valueOption
+                                ?: Locales.english.toLanguageTag(),
+                            firstName = firstName.trim().ifBlank { null },
+                            lastName = lastName.trim().ifBlank { null },
+                            email = email.trim().ifBlank { null },
+                            phoneNumber = phone.trim().ifBlank { null },
+                            gender = selectedGender?.valueOption?.ifBlank { null },
+                            country = selectedCountry?.valueOption ?: EnumCountry.Unsupported,
+                            bio = bio.trim().ifBlank { null },
+                            notifyByEmail = notifyEmail,
+                            notifyBySms = notifySms,
+                            preferredAreaUnit = selectedAreaUnit?.valueOption ?: EnumAreaUnit.ACRE,
+                            darkMode = darkMode,
+                        )
+                        viewModel.savePreferences(prefs)
+                    }
+                }
+            )
+        }
     ) { padding ->
         Column(
             modifier = Modifier
                 .padding(padding)
-                .padding(16.dp)
+                .padding(horizontal = AkilimoSpacing.md)
                 .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(AkilimoSpacing.xs),
         ) {
             LabeledTextField(
                 sectionLabel = stringResource(R.string.lbl_first_name),
@@ -183,7 +213,6 @@ fun UserSettingsScreen(navController: NavHostController) {
                 onValueChange = { phone = it; phoneError = null },
                 error = phoneError
             )
-            Spacer(Modifier.height(12.dp))
 
             AkilimoDropdown(
                 label = stringResource(R.string.lbl_gender),
@@ -193,8 +222,6 @@ fun UserSettingsScreen(navController: NavHostController) {
                 displayText = { it.displayLabel },
                 modifier = Modifier.fillMaxWidth(),
             )
-            Spacer(Modifier.height(8.dp))
-
             AkilimoDropdown(
                 label = stringResource(R.string.lbl_language),
                 options = languageOptions,
@@ -203,8 +230,6 @@ fun UserSettingsScreen(navController: NavHostController) {
                 displayText = { it.displayLabel },
                 modifier = Modifier.fillMaxWidth(),
             )
-            Spacer(Modifier.height(8.dp))
-
             AkilimoDropdown(
                 label = stringResource(R.string.lbl_country),
                 options = countryOptions,
@@ -213,8 +238,6 @@ fun UserSettingsScreen(navController: NavHostController) {
                 displayText = { it.displayLabel },
                 modifier = Modifier.fillMaxWidth(),
             )
-            Spacer(Modifier.height(8.dp))
-
             AkilimoDropdown(
                 label = stringResource(R.string.lbl_area_unit),
                 options = areaUnitOptions,
@@ -223,7 +246,6 @@ fun UserSettingsScreen(navController: NavHostController) {
                 displayText = { it.displayLabel },
                 modifier = Modifier.fillMaxWidth(),
             )
-            Spacer(Modifier.height(12.dp))
 
             SwitchRow(
                 label = stringResource(R.string.lbl_notify_email),
@@ -240,44 +262,6 @@ fun UserSettingsScreen(navController: NavHostController) {
                 checked = darkMode,
                 onCheckedChange = { darkMode = it },
             )
-
-            Spacer(Modifier.height(16.dp))
-
-            Button(
-                onClick = {
-                    val validEmail = android.util.Patterns.EMAIL_ADDRESS
-                    val validPhone = android.util.Patterns.PHONE
-
-                    if (email.isNotBlank() && !validEmail.matcher(email).matches()) {
-                        emailError = context.getString(R.string.lbl_valid_email_req)
-                        return@Button
-                    }
-                    if (phone.isNotBlank() && !validPhone.matcher(phone).matches()) {
-                        phoneError = context.getString(R.string.lbl_valid_number_req)
-                        return@Button
-                    }
-
-                    val prefs = UserPreferences(
-                        languageCode = selectedLanguage?.valueOption ?: Locales.english.toLanguageTag(),
-                        firstName = firstName.trim().ifBlank { null },
-                        lastName = lastName.trim().ifBlank { null },
-                        email = email.trim().ifBlank { null },
-                        phoneNumber = phone.trim().ifBlank { null },
-                        gender = selectedGender?.valueOption?.ifBlank { null },
-                        country = selectedCountry?.valueOption ?: EnumCountry.Unsupported,
-                        bio = bio.trim().ifBlank { null },
-                        notifyByEmail = notifyEmail,
-                        notifyBySms = notifySms,
-                        preferredAreaUnit = selectedAreaUnit?.valueOption ?: EnumAreaUnit.ACRE,
-                        darkMode = darkMode,
-                    )
-                    viewModel.savePreferences(prefs)
-                },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(stringResource(R.string.lbl_save))
-            }
         }
     }
 }
-

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/CassavaMarketScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/CassavaMarketScreen.kt
@@ -22,7 +22,10 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -90,11 +93,16 @@ fun CassavaMarketScreen(
         CassavaMarketViewModel.MarketChoice.NONE -> false
     }
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
-                title = stringResource(R.string.lbl_cassava_price),
-                onBack = { navController.popBackStack() }
+                title = stringResource(R.string.lbl_cassava_market_outlet),
+                collapsedTitle = stringResource(R.string.lbl_cassava),
+                scrollBehavior = scrollBehavior,
+                onBack = { navController.popBackStack() },
             )
         },
         bottomBar = {

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/CassavaYieldScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/CassavaYieldScreen.kt
@@ -12,7 +12,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -51,10 +54,15 @@ fun CassavaYieldScreen(
         viewModel.seedYields(buildCassavaYieldSeeds(context, areaUnit))
     }
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(R.string.lbl_typical_yield),
+                collapsedTitle = stringResource(R.string.lbl_yield),
+                scrollBehavior = scrollBehavior,
                 onBack = { navController.popBackStack() },
                 actions = {
                     IconButton(onClick = { isGridLayout = !isGridLayout }) {

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/DatesScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/DatesScreen.kt
@@ -14,7 +14,10 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -171,11 +174,16 @@ fun DatesScreen(
         ) { DatePicker(state = datePickerState, modifier = Modifier.weight(1f, fill = false)) }
     }
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(R.string.lbl_consider_alternative_planting),
-                onBack = { navController.popBackStack() }
+                collapsedTitle = stringResource(R.string.lbl_dates),
+                scrollBehavior = scrollBehavior,
+                onBack = { navController.popBackStack() },
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/FertilizerScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/FertilizerScreen.kt
@@ -25,7 +25,10 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -38,7 +41,6 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -86,6 +88,8 @@ fun FertilizerScreen(
         else -> R.string.lbl_available_fertilizers
     }
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     fun openSheet(fertilizer: Fertilizer) {
         selectedFertilizer = fertilizer
         prices = emptyList()
@@ -95,10 +99,13 @@ fun FertilizerScreen(
     }
 
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(titleRes),
                 subtitle = stringResource(R.string.lbl_available_fertilizers_subtitle),
+                collapsedTitle = stringResource(R.string.lbl_fertilizers),
+                scrollBehavior = scrollBehavior,
                 onBack = { navController.popBackStack() },
                 actions = {
                     IconButton(onClick = { viewModel.toggleLayout() }) {
@@ -206,14 +213,14 @@ fun FertilizerScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
+                    .padding(horizontal = AkilimoSpacing.md)
                     .verticalScroll(rememberScrollState())
             ) {
                 Text(
                     text = fert.name.orEmpty(),
                     style = MaterialTheme.typography.titleMedium
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(AkilimoSpacing.xs))
 
                 prices.forEach { price ->
                     val label = when {
@@ -234,12 +241,12 @@ fun FertilizerScreen(
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(start = 48.dp)
+                                .padding(start = AkilimoSpacing.xxxl)
                         )
                     }
                 }
 
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(AkilimoSpacing.xs))
 
                 Button(
                     onClick = {
@@ -266,13 +273,15 @@ fun FertilizerScreen(
                         }
                     },
                     enabled = isConfirmEnabled,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = AkilimoSpacing.xs),
+                    shape = MaterialTheme.shapes.medium,
                 ) {
                     Text(stringResource(R.string.lbl_confirm))
                 }
 
                 if (state.selectedIds.contains(fert.id)) {
-                    Spacer(modifier = Modifier.height(8.dp))
                     OutlinedButton(
                         onClick = {
                             fert.id?.let { viewModel.deselectFertilizer(it) }
@@ -280,13 +289,14 @@ fun FertilizerScreen(
                                 showPriceSheet = false
                             }
                         },
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = MaterialTheme.shapes.medium,
                     ) {
                         Text(stringResource(R.string.lbl_remove))
                     }
                 }
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(AkilimoSpacing.md))
             }
         }
     }

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/InvestmentAmountScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/InvestmentAmountScreen.kt
@@ -15,7 +15,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,11 +48,16 @@ fun InvestmentAmountScreen(
 
     var selectedItem by remember { mutableStateOf<InvestmentAmount?>(null) }
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(R.string.lbl_investment_amount),
-                onBack = { navController.popBackStack() }
+                collapsedTitle = stringResource(R.string.lbl_investment),
+                scrollBehavior = scrollBehavior,
+                onBack = { navController.popBackStack() },
             )
         },
         bottomBar = {

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/MaizeMarketScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/MaizeMarketScreen.kt
@@ -9,7 +9,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -85,11 +88,16 @@ fun MaizeMarketScreen(
         }
     }
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(R.string.lbl_market_outlet_maize),
-                onBack = { navController.popBackStack() }
+                collapsedTitle = stringResource(R.string.lbl_maize),
+                scrollBehavior = scrollBehavior,
+                onBack = { navController.popBackStack() },
             )
         }
     ) { padding ->

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/MaizePerformanceScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/MaizePerformanceScreen.kt
@@ -12,7 +12,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,10 +48,15 @@ fun MaizePerformanceScreen(
     var isGridLayout by remember { mutableStateOf(true) }
     var selectedOption by remember { mutableStateOf<MaizePerfOption?>(null) }
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(R.string.lbl_maize_performance),
+                collapsedTitle = stringResource(R.string.lbl_maize),
+                scrollBehavior = scrollBehavior,
                 onBack = { navController.popBackStack() },
                 actions = {
                     IconButton(onClick = { isGridLayout = !isGridLayout }) {

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/ManualTillageCostScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/ManualTillageCostScreen.kt
@@ -12,7 +12,10 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -67,11 +70,16 @@ fun ManualTillageCostScreen(
     val areaUnitLabel = state.enumAreaUnit.label(context)
     val farmSize = state.farmSize
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(R.string.lbl_cost_of_manual_tillage),
-                onBack = { navController.popBackStack() }
+                collapsedTitle = stringResource(R.string.lbl_tillage),
+                scrollBehavior = scrollBehavior,
+                onBack = { navController.popBackStack() },
             )
         }
     ) { padding ->

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/SweetPotatoMarketScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/SweetPotatoMarketScreen.kt
@@ -9,7 +9,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -67,11 +70,16 @@ fun SweetPotatoMarketScreen(
 
     val unitOptions = EnumUnitOfSale.entries.filter { it.isUniversal }
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(R.string.lbl_market_outlet_sweet_potato),
-                onBack = { navController.popBackStack() }
+                collapsedTitle = stringResource(R.string.lbl_sweet_potato),
+                scrollBehavior = scrollBehavior,
+                onBack = { navController.popBackStack() },
             )
         }
     ) { padding ->

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/TractorAccessScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/TractorAccessScreen.kt
@@ -12,7 +12,10 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -74,11 +77,16 @@ fun TractorAccessScreen(
     val areaUnitLabel = state.enumAreaUnit.label(context)
     val farmSize = state.farmSize
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(R.string.lbl_tractor_access),
-                onBack = { navController.popBackStack() }
+                collapsedTitle = stringResource(R.string.lbl_tractor_access_title),
+                scrollBehavior = scrollBehavior,
+                onBack = { navController.popBackStack() },
             )
         }
     ) { padding ->

--- a/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/WeedControlCostsScreen.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/screens/usecases/WeedControlCostsScreen.kt
@@ -9,7 +9,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -63,11 +66,16 @@ fun WeedControlCostsScreen(
 
     val weedMethods = EnumWeedControlMethod.entries
 
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BackTopAppBar(
                 title = stringResource(R.string.lbl_cost_of_weed_control),
-                onBack = { navController.popBackStack() }
+                collapsedTitle = stringResource(R.string.lbl_weeding),
+                scrollBehavior = scrollBehavior,
+                onBack = { navController.popBackStack() },
             )
         }
     ) { padding ->

--- a/app/src/main/java/com/akilimo/mobile/ui/theme/AkilimoColors.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/theme/AkilimoColors.kt
@@ -6,27 +6,27 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 
 // ── Light palette ────────────────────────────────────────────────────────────
-private val Primary = Color(0xFF2E5900) // Deepened for sunlight contrast (was 0xFF3D7600)
+private val Primary = Color(0xFF2E5900)
 private val OnPrimary = Color(0xFFFFFFFF)
-private val PrimaryContainer = Color(0xFFC8E68A) // Warmer, less neon (was 0xFFBAEE82)
-private val OnPrimaryContainer = Color(0xFF0E2400) // Match deeper primary (was 0xFF0D2100)
+private val PrimaryContainer = Color(0xFFD3EABC) // Refined for better vibrancy
+private val OnPrimaryContainer = Color(0xFF0E2400)
 
-private val Secondary = Color(0xFF4A5200) // Muted olive-earth (was 0xFF586200)
+private val Secondary = Color(0xFF58624E) // Neutral olive
 private val OnSecondary = Color(0xFFFFFFFF)
-private val SecondaryContainer = Color(0xFFD4E175) // Less saturated (was 0xFFDCE87A)
-private val OnSecondaryContainer = Color(0xFF161900) // Adjusted
+private val SecondaryContainer = Color(0xFFDCE6CF)
+private val OnSecondaryContainer = Color(0xFF151E0F)
 
 private val Tertiary = Color(0xFFB5162A)
 private val OnTertiary = Color(0xFFFFFFFF)
 private val TertiaryContainer = Color(0xFFFFDADC)
 private val OnTertiaryContainer = Color(0xFF40000D)
 
-private val Background = Color(0xFFF8FBF4) // Softer green-white (was 0xFFF5FCE9)
-private val OnBackground = Color(0xFF1C1F16) // Deeper charcoal-green (was 0xFF181D12)
-private val Surface = Color(0xFFF8FBF4) // Match background (was 0xFFF5FCE9)
-private val OnSurface = Color(0xFF1C1F16) // Match (was 0xFF181D12)
-private val SurfaceVariant = Color(0xFFE3E8D8) // Neutral gray-green (was 0xFFDCE6C8)
-private val OnSurfaceVariant = Color(0xFF424940)
+private val Background = Color(0xFFFDFDF6) // Lighter background
+private val OnBackground = Color(0xFF1A1C18)
+private val Surface = Color(0xFFFDFDF6)
+private val OnSurface = Color(0xFF1A1C18)
+private val SurfaceVariant = Color(0xFFE1E4D5)
+private val OnSurfaceVariant = Color(0xFF44483E)
 
 private val Error = Color(0xFFBA1A1A)
 private val OnError = Color(0xFFFFFFFF)

--- a/app/src/main/java/com/akilimo/mobile/ui/theme/AkilimoShapes.kt
+++ b/app/src/main/java/com/akilimo/mobile/ui/theme/AkilimoShapes.kt
@@ -8,11 +8,11 @@ val AkilimoShapes = Shapes(
     // ExtraSmall — chips, compact inputs
     extraSmall = RoundedCornerShape(4.dp),
     // Small — text fields, small cards
-    small = RoundedCornerShape(8.dp),
+    small = RoundedCornerShape(12.dp),
     // Medium — cards (matches ShapeAppearance.Akilimo.Card = 12dp)
-    medium = RoundedCornerShape(12.dp),
+    medium = RoundedCornerShape(20.dp),
     // Large — bottom sheets, dialogs (matches ShapeAppearance.Akilimo.Large = 24dp)
-    large = RoundedCornerShape(24.dp),
+    large = RoundedCornerShape(32.dp),
     // ExtraLarge — dialogs, bottom sheets (matches M3 default 28dp)
-    extraLarge = RoundedCornerShape(28.dp),
+    extraLarge = RoundedCornerShape(40.dp),
 )

--- a/app/src/main/res/values-rw-rRW/strings.xml
+++ b/app/src/main/res/values-rw-rRW/strings.xml
@@ -91,7 +91,6 @@
     <string name="lbl_height_of_maize_at_tasseling">Ibigori bidafite ifumbire mubisanzwe bigera ku burebure bwa cm 150. Ni ubuhe burebure bw\'ibigori bigeze mu gihe cyo guheka mu murima wawe mu gihe nta fumbire washyizemo?</string>
     <string name="lbl_maize_performance_poor">Ubu butaka ni bubi kandi ntibisanzwe</string>
     <string name="lbl_maize_performance_rich">Ubu butaka ni bwiza kandi ntibisanzwe</string>
-    <string name="lbl_cassava_price">Ibiciro by\'imyumbati</string>
     <string name="lbl_market_outlet">Ni ikihe giciro utegereje ku myumbati yawe?</string>
     <string name="lbl_maize_market">Gurisha ibigori byawe</string>
     <string name="lbl_sweet_potato_market">Gurisha ibijumba byawe</string>

--- a/app/src/main/res/values-sw-rTZ/strings.xml
+++ b/app/src/main/res/values-sw-rTZ/strings.xml
@@ -91,7 +91,6 @@
     <string name="lbl_height_of_maize_at_tasseling">Mahindi bila mbolea kawaida hufikia urefu wa kifua karibu 150cm. Je? Ni urefu gani wa mazao yako ya mahindi kwenye shamba lako ukiwa bila mbolea</string>
     <string name="lbl_maize_performance_poor">Hizi ni dalili za udongo usio na rutuba lakini sio za kawaida</string>
     <string name="lbl_maize_performance_rich">Hizi ni dalili za udongo wenye rutuba lakini sio za kawaida</string>
-    <string name="lbl_cassava_price">Bei za muhogo</string>
     <string name="lbl_market_outlet">Unatarajia bei gani kwa muhogo wako wakati wa mavuno?</string>
     <string name="lbl_maize_market">Uza mahindi yako</string>
     <string name="lbl_sweet_potato_market">Uza Viazi Vitamu vyako</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,13 +107,25 @@
     <string name="lbl_manual_location">Select location manually</string>
 
     <string name="lbl_recommendations">Recommendations</string>
+    <string name="lbl_fertilizers">Fertilizers</string>
     <string name="lbl_fertilizer_recommendations">Fertilizer recommendations</string>
+    <string name="lbl_dates">Dates</string>
+    <string name="lbl_cassava">Cassava</string>
+    <string name="lbl_yield">Cassava Yield</string>
+    <string name="lbl_investment">Investment</string>
+    <string name="lbl_maize">Maize Heigh</string>
+    <string name="lbl_tillage">Tillage</string>
+    <string name="lbl_sweet_potato">Sweet Potato</string>
+    <string name="lbl_tractor_access_title">Tractor</string>
     <string name="lbl_intercropping">Intercropping</string>
 
     <string name="lbl_intercropping_maize">Cassava maize intercrop</string>
+    <string name="lbl_intercropping_maize_title">Maize Intercrop</string>
     <string name="lbl_intercropping_sweet_potato">Cassava sweet potato intercrop</string>
+    <string name="lbl_intercropping_sweet_potato_title">Sweet Potato Intercrop</string>
     <string name="lbl_scheduled_planting_and_high_starch">Scheduled planting and high starch</string>
     <string name="lbl_best_planting_practices">Best planting practices</string>
+    <string name="lbl_best_planting_practices_title">Planting Practices</string>
     <string name="lbl_weed_management">Weed management</string>
 
 
@@ -148,7 +160,7 @@
     <string name="lbl_maize_performance_poor">These are very poor soil conditions and not very common</string>
     <string name="lbl_maize_performance_rich">These are very rich soil conditions and not very common</string>
 
-    <string name="lbl_cassava_price">Cassava prices</string>
+    <string name="lbl_cassava_market_outlet">Cassava prices</string>
     <string name="lbl_market_outlet">What price do you expect for your cassava?</string>
     <string name="lbl_maize_market">Sell your Maize</string>
     <string name="lbl_sweet_potato_market">Sell your Sweet Potatoes</string>
@@ -544,6 +556,8 @@
 
     <string name="lbl_already_planted_title">Already planted</string>
     <string name="lbl_already_planted_text">It appears you have already planted, so you cannot set the planting flexibility</string>
+    <string name="lbl_disclaimer">Disclaimer</string>
+    <string name="lbl_terms">Terms &amp; Conditions</string>
     <string name="lbl_agree_to_terms">I accept the terms and conditions of the application</string>
     <string name="lbl_agree_to_disclaimer">Please confirm you have read and understood this disclaimer.</string>
     <string name="lbl_accept_terms_prompt">Accept the terms and conditions before proceeding</string>


### PR DESCRIPTION
## Summary

- **Parallax hero on RecommendationsScreen**: replaced flat `LargeTopAppBar` with a 240dp `Box`-based layout; hero uses `Brush.verticalGradient` depth overlay and `translationY` parallax driven by `LazyListState`; overlaid `TopAppBar` fades in on scroll
- **Collapsible `LargeTopAppBar` across all usecase screens**: extended `BackTopAppBar` with optional `collapsedTitle` + `scrollBehavior` params; expanded state shows full title/subtitle via crossfading `Box`; `Modifier.layout` shrinks the expanded `Column` height to zero when collapsed, eliminating blank-space artifact
- **Onboarding step progress bar**: `LinearProgressIndicator` with `animateFloatAsState` added to `OnboardingScreen` top bar for all steps except Welcome; progress widget removed from `WizardBottomBar`
- **`EnumAdvice` title/subtitle split**: added `titleResId` + `title(context)` to `EnumAdvice`; `AdviceOptionCard` now shows short title (`bodyLarge`) above long label subtitle (`bodySmall/onSurfaceVariant`)
- **`BrandHeader` component**: reusable full-width gradient brand hero with AKILIMO logo, used in `WelcomeStep`
- **Repository observer cleanup**: removed deprecated fertilizer observer from `FertilizerViewModel`

## Screens updated with collapsible top bar

`FertilizerScreen`, `DatesScreen`, `CassavaMarketScreen`, `CassavaYieldScreen`, `InvestmentAmountScreen`, `MaizeMarketScreen`, `MaizePerformanceScreen`, `ManualTillageCostScreen`, `SweetPotatoMarketScreen`, `TractorAccessScreen`, `WeedControlCostsScreen`

## Test plan

- [ ] Launch app → verify `RecommendationsScreen` hero parallaxes on scroll; `TopAppBar` fades from transparent to opaque
- [ ] Open any usecase screen → scroll down → verify title collapses to single word with no blank gap
- [ ] Open any usecase screen → verify expanded state shows full title
- [ ] Run through onboarding → verify step-labelled top bar + animated progress bar on every step after Welcome
- [ ] Tap any `AdviceOptionCard` on recommendations → verify short title + subtitle layout
- [ ] `./gradlew :app:compileDebugKotlin` passes with no errors
- [ ] `./gradlew testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)